### PR TITLE
Translate py

### DIFF
--- a/languages/haskell/README.md
+++ b/languages/haskell/README.md
@@ -4,16 +4,18 @@ This will evolve into a Haskell-native dmnmd toolsuite.
 
 Wouldn't it be cool if we could, using Template Haskell QuasiQuoting, write code like this?
 
+The "lambda" output column is *not* part of the DMN specification. But we like higher-order functions!
+
 ``` haskell
 let whatdish = [dmnmd|
-| U | Season               | Guest Count | Dish (out)                   | # Annotation  |
-|---|----------------------|-------------|------------------------------|---------------|
-| 1 | Fall                 | <= 8        | Spareribs                    |               |
-| 2 | Winter               | <= 8        | Roastbeef                    |               |
-| 3 | Spring               | <= 4        | Dry Aged Gourmet Steak       |               |
-| 4 | Spring               | [5..8]      | Steak                        |               |
-| 5 | Fall, Winter, Spring | > 8         | Stew                         |               |
-| 6 | Summer               | -           | Light Salad and a nice Steak | Hey, why not? |
+| U | Season               | Guest Count | Dish (out)                   | Lambda (out) | # Annotation  |
+|---+----------------------+-------------+------------------------------+--------------+---------------|
+| 1 | Fall                 | <= 8        | Spareribs                    | 2            |               |
+| 2 | Winter               | <= 8        | Roastbeef                    | <2           |               |
+| 3 | Spring               | <= 4        | Dry Aged Gourmet Steak       | <=4          |               |
+| 4 | Spring               | [5..8]      | Steak                        | >2           |               |
+| 5 | Fall, Winter, Spring | > 8         | Stew                         | [4..20]      |               |
+| 6 | Summer               | -           | Light Salad and a nice Steak | ==20         | Hey, why not? |
 
 |]
 

--- a/languages/haskell/app/Main.hs
+++ b/languages/haskell/app/Main.hs
@@ -15,6 +15,8 @@ import System.Console.Haskeline
 import DMN.Types
 import DMN.DecisionTable
 import DMN.Translate.JS
+import DMN.Translate.PY
+import DMN.Translate.FEELhelpers
 import DMN.XML.ParseDMN (parseDMN)
 import DMN.XML.XmlToDmnmd (convertAll)
 
@@ -116,6 +118,7 @@ showToJSON dtable cols' = if not (null cols') then zipWith showFeels ((getOutput
 outputTo :: Handle -> FileFormat -> ArgOptions -> DecisionTable -> IO ()
 outputTo h Js opts dtable = hPutStrLn h $ toJS (JSOpts (Options.propstyle opts) (outformat opts == Ts)) dtable
 outputTo h Ts opts dtable = hPutStrLn h $ toJS (JSOpts (Options.propstyle opts) (outformat opts == Ts)) dtable
+outputTo h Py opts dtable = hPutStrLn h $ toPY (PYOpts (Options.propstyle opts) (outformat opts == Ts)) dtable
 outputTo _ filetype _ _   = crash $ "outputTo: Unsupported file type: " ++ show filetype 
                                    ++ ".\nSupported output formats are 'ts' and 'js'"
 

--- a/languages/haskell/app/Main.hs
+++ b/languages/haskell/app/Main.hs
@@ -122,7 +122,7 @@ outputTo h Js opts dtable = hPutStrLn h $ toJS (JSOpts (Options.propstyle opts) 
 outputTo h Ts opts dtable = hPutStrLn h $ toJS (JSOpts (Options.propstyle opts) (outformat opts == Ts)) dtable
 outputTo h Py opts dtable = hPutStrLn h $ toPY (PYOpts (Options.propstyle opts))  dtable
 outputTo _ filetype _ _   = crash $ "outputTo: Unsupported file type: " ++ show filetype 
-                                   ++ ".\nSupported output formats are 'ts' and 'js'"
+                                   ++ ".\nSupported output formats are 'ts', 'js' and 'py'"
 
 myOutHandle :: FilePath -> IO Handle
 myOutHandle h = if h == "-" then return stdout else openFile h WriteMode

--- a/languages/haskell/app/Options.hs
+++ b/languages/haskell/app/Options.hs
@@ -67,7 +67,7 @@ parseFileFormat = OA.eitherReader $ \case
     "py" -> return Py
     "md" -> return Md
     "xml" -> return Xml
-    _    -> Left "Accepted file types are 'ts', 'js', 'xml', and 'md'."
+    _    -> Left "Accepted file types are 'ts', 'js', 'py', 'xml', and 'md'."
 
 testExtThing :: String
 testExtThing = takeExtension "test/simulation.dmn"

--- a/languages/haskell/app/Options.hs
+++ b/languages/haskell/app/Options.hs
@@ -52,7 +52,7 @@ detectOutformat opts = opts { outformat = detectFormat [out opts] (outformat opt
 detectInformat :: ArgOptions -> ArgOptions
 detectInformat opts = opts { informat = detectFormat (input opts) (informat opts)}
 
-data FileFormat = Ts | Js | Xml | Md | Unknown
+data FileFormat = Ts | Js | Py | Xml | Md | Unknown
   deriving (Show, Eq)
 
 -- | A file format option
@@ -64,6 +64,7 @@ parseFileFormat :: OA.ReadM FileFormat
 parseFileFormat = OA.eitherReader $ \case 
     "ts" -> return Ts
     "js" -> return Js
+    "py" -> return Py
     "md" -> return Md
     "xml" -> return Xml
     _    -> Left "Accepted file types are 'ts', 'js', 'xml', and 'md'."
@@ -75,6 +76,7 @@ fileExtensionMappings :: [(String, FileFormat)]
 fileExtensionMappings =
   [ (".ts", Ts)
   , (".js", Js)
+  , (".py", Py)
   , (".dmn", Xml)
   , (".md", Md)
   ]

--- a/languages/haskell/app/ParseMarkdown.hs
+++ b/languages/haskell/app/ParseMarkdown.hs
@@ -53,7 +53,9 @@ parseMarkdown opts1 = do
     mylog opts msg = when (verbose opts) $ myerr opts msg
 
     parseChunk :: ArgOptions -> InputChunk -> IO [DecisionTable]
-    parseChunk opts mychunk = do
+    parseChunk opts mychunk
+     | chunkLines mychunk == ["|]"] = pure [] -- special case, sometimes |] closes a quasiquotation block
+     | otherwise = do
       let parseResult = parseOnly (parseTable (chunkName mychunk) <?> "parseTable")
             $ T.pack $ unlines $ chunkLines mychunk
       let printParseError myPTfail =

--- a/languages/haskell/dmnmd.cabal
+++ b/languages/haskell/dmnmd.cabal
@@ -1,0 +1,138 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           dmnmd
+version:        0.1.0.1
+synopsis:       CLI to inter-convert DMN tables from Markdown format to JS, and more
+description:    Decision Model & Notation format conversion and code generation. Please see the README on GitHub at <https://github.com/smucclaw/complaw/dmnmd>
+category:       Code Generation
+homepage:       https://github.com/smucclaw/complaw#readme
+bug-reports:    https://github.com/smucclaw/complaw/issues
+author:         Meng Weng Wong
+maintainer:     mwwong@smu.edu.sg
+copyright:      2020 Singapore Management University
+license:        BSD3
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/smucclaw/complaw
+
+library
+  exposed-modules:
+      DMN.DecisionTable
+      DMN.ParseFEEL
+      DMN.ParseTable
+      DMN.ParsingUtils
+      DMN.SFeelGrammar
+      DMN.Translate.FEELhelpers
+      DMN.Translate.JS
+      DMN.Translate.PY
+      DMN.Types
+      DMN.XML.ParseDMN
+      DMN.XML.PickleHelpers
+      DMN.XML.XmlToDmnmd
+      Text.XML.HXT.Pickle.TupleInstances
+  other-modules:
+      Paths_dmnmd
+  hs-source-dirs:
+      src
+  ghc-options: -Wno-unused-matches -fwrite-ide-info -hiedir=.hie
+  build-depends:
+      MissingH
+    , attoparsec
+    , base >=4.7 && <5
+    , containers
+    , haskeline
+    , hspec
+    , hspec-attoparsec
+    , hspec-golden
+    , hspec-megaparsec
+    , hxt
+    , lens
+    , megaparsec
+    , optparse-applicative
+    , parser-combinators
+    , pretty-simple
+    , raw-strings-qq
+    , regex-pcre
+    , scientific
+    , split
+    , text
+  default-language: Haskell2010
+
+executable dmnmd
+  main-is: Main.hs
+  other-modules:
+      Options
+      ParseMarkdown
+      Paths_dmnmd
+  hs-source-dirs:
+      app
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      MissingH
+    , attoparsec
+    , base >=4.7 && <5
+    , containers
+    , dmnmd
+    , filepath
+    , haskeline
+    , hspec
+    , hspec-attoparsec
+    , hspec-golden
+    , hspec-megaparsec
+    , hxt
+    , lens
+    , megaparsec
+    , optparse-applicative
+    , parser-combinators
+    , pretty-simple
+    , raw-strings-qq
+    , regex-pcre
+    , scientific
+    , split
+    , text
+  default-language: Haskell2010
+
+test-suite dmnmd-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      DmnXmlSpec
+      ParseFEELSpec
+      ParserSpecHelpers
+      SFeelGrammar
+      Paths_dmnmd
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      MissingH
+    , attoparsec
+    , base >=4.7 && <5
+    , containers
+    , dmnmd
+    , haskeline
+    , hspec
+    , hspec-attoparsec
+    , hspec-golden
+    , hspec-megaparsec
+    , hxt
+    , lens
+    , megaparsec
+    , optparse-applicative
+    , parser-combinators
+    , pretty-simple
+    , raw-strings-qq
+    , regex-pcre
+    , scientific
+    , split
+    , text
+  default-language: Haskell2010

--- a/languages/haskell/src/DMN/Translate/FEELhelpers.hs
+++ b/languages/haskell/src/DMN/Translate/FEELhelpers.hs
@@ -6,34 +6,48 @@ import Data.Char
 import Data.List
 import DMN.Types
 
+capitalize :: String -> String -- This file is the "root" for generating the if-else condittions, and should be imported in fileformat-specific translation scripts, so I thought it'd be best to place this here
+capitalize [] = []
+capitalize (x:xs) = toUpper x : xs
+
+-- Helper functions are are intended for use in generating lambda 
+-- functions in the respective outputs (ts, js, python)
+lambdaHeader :: String -> String
+lambdaHeader optform
+  | optform == "py" = "lambda x: "
+  | (optform == "ts") || (optform == "js") = "(x)=> "
+  | otherwise = error "Currently only ts, js and py formats are supported"
+
+
 wrapArray :: String -> [String] -> String
 wrapArray myop xs = "[" ++ intercalate myop xs ++ "]"
 
-showFeels ch fexps = "\"" ++ varname ch ++ "\":" ++ if squash
-                                                    then showFeel $ head fexps
-                                                    else wrapArray "," (showFeel <$> fexps)
+showFeels optform ch fexps = "\"" ++ varname ch ++ "\":" ++ if squash
+                                                    then showFeel optform  $ head fexps
+                                                    else wrapArray "," (showFeel optform <$> fexps)
   where squash = maybe True (\case
                                 DMN_List _ -> False
                                 _          -> True) (vartype ch)
           
-showFeel :: FEELexp -> String
-showFeel (FNullary (VS str))  = show str
-showFeel (FNullary (VN num))  = show num
-showFeel (FNullary (VB bool)) = toLower <$> show bool
-showFeel (FSection Feq  (VB rhs)) = "(x)=>x === "++ (toLower <$> show rhs)
-showFeel (FSection Feq  (VS rhs)) = "(x)=>x === "++ show rhs
-showFeel (FSection Feq  (VN rhs)) = "(x)=>x === "++ show rhs
-showFeel (FSection Flt  (VN rhs)) = "(x)=>x < "++show rhs
-showFeel (FSection Flte (VN rhs)) = "(x)=>x <="++show rhs
-showFeel (FSection Fgt  (VN rhs)) = "(x)=>x > "++show rhs
-showFeel (FSection Fgte (VN rhs)) = "(x)=>x >="++show rhs
-showFeel (FInRange lower upper)   = "(x)=>" ++ show lower ++ "<= x && x <= " ++ show upper
-showFeel (FFunction (FNF1 var))     = var
-showFeel (FFunction (FNF0 (VS str))) = "\"" ++ str ++ "\""
-showFeel (FFunction (FNF0 (VB bool))) = toLower <$> show bool
-showFeel (FFunction (FNF0 (VN num)))  = show num
-showFeel (FFunction (FNF3 lhs fnop2 rhs))  = "(" ++ showFeel (FFunction lhs) ++ showFNOp2 fnop2 ++ showFeel (FFunction rhs) ++ ")"
-showFeel  FAnything               = "undefined"
+showFeel :: String -> FEELexp -> String
+showFeel _ (FNullary (VS str))  = show str
+showFeel _ (FNullary (VN num))  = show num
+showFeel optform (FNullary (VB bool)) = if optform == "py" then capitalize (toLower <$> show bool) else toLower <$> show bool 
+showFeel optform (FSection Feq  (VB rhs)) = lambdaHeader optform ++ "x" ++ showFNComp optform FNEq  ++ (toLower <$> show rhs)
+showFeel optform (FSection Feq  (VS rhs)) = lambdaHeader optform ++ "x" ++ showFNComp optform FNEq  ++ show rhs
+showFeel optform (FSection Feq  (VN rhs)) = lambdaHeader optform ++ "x" ++ showFNComp optform FNEq  ++ show rhs
+showFeel optform (FSection Flt  (VN rhs)) = lambdaHeader optform ++ "x" ++ showFNComp optform FNLt  ++ show rhs
+showFeel optform (FSection Flte (VN rhs)) = lambdaHeader optform ++ "x" ++ showFNComp optform FNLeq ++ show rhs
+showFeel optform (FSection Fgt  (VN rhs)) = lambdaHeader optform ++ "x" ++ showFNComp optform FNGt  ++ show rhs
+showFeel optform (FSection Fgte (VN rhs)) = lambdaHeader optform ++ "x" ++ showFNComp optform FNGeq ++show rhs
+showFeel optform (FInRange lower upper)   = lambdaHeader optform ++ show lower ++ showFNComp optform FNLeq ++ "x" 
+                                            ++ showFNLog optform FNAnd ++ "x" ++ showFNComp optform FNLeq  ++ show upper
+showFeel _ (FFunction (FNF1 var))     = var
+showFeel _ (FFunction (FNF0 (VS str))) = "\"" ++ str ++ "\""
+showFeel _ (FFunction (FNF0 (VB bool))) = toLower <$> show bool
+showFeel _ (FFunction (FNF0 (VN num)))  = show num
+showFeel optform (FFunction (FNF3 lhs fnop2 rhs))  = "(" ++ showFeel optform (FFunction lhs) ++ showFNOp2 fnop2 ++ showFeel optform (FFunction rhs) ++ ")"
+showFeel  _ FAnything               = "undefined"
 
 showFNOp2 :: FNOp2 -> String
 showFNOp2 FNMul   = " * "
@@ -41,3 +55,24 @@ showFNOp2 FNDiv   = " / "
 showFNOp2 FNPlus  = " + "
 showFNOp2 FNMinus = " - "
 showFNOp2 FNExp   = " ** "
+
+showFNLog :: String -> FNLog -> String
+showFNLog "py" FNNot   = "not  "
+showFNLog "py" FNAnd  = " and "
+showFNLog "py" FNOr   = " or "
+showFNLog "ts" FNNot   = "!"
+showFNLog "ts" FNAnd  = " && "
+showFNLog "ts" FNOr   = " || "
+showFNLog "js" x      = showFNLog "ts" x
+
+showFNComp :: String -> FNComp -> String
+showFNComp "py" FNEq  = " == "
+showFNComp "py" FNNeq = " != "
+showFNComp "py" FNLt  = " < "
+showFNComp "py" FNLeq = " <= "
+showFNComp "py" FNGt  = " > "
+showFNComp "py" FNGeq = " >= "
+showFNComp "ts" FNEq  = " === "
+showFNComp "ts" FNNeq = " !== "
+showFNComp "ts" x     = showFNComp "py" x
+showFNComp "js" x     = showFNComp "ts" x

--- a/languages/haskell/src/DMN/Translate/FEELhelpers.hs
+++ b/languages/haskell/src/DMN/Translate/FEELhelpers.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE LambdaCase #-}
+
+module DMN.Translate.FEELhelpers where
+
+import Data.Char
+import Data.List
+import DMN.Types
+
+wrapArray :: String -> [String] -> String
+wrapArray myop xs = "[" ++ intercalate myop xs ++ "]"
+
+showFeels ch fexps = "\"" ++ varname ch ++ "\":" ++ if squash
+                                                    then showFeel $ head fexps
+                                                    else wrapArray "," (showFeel <$> fexps)
+  where squash = maybe True (\case
+                                DMN_List _ -> False
+                                _          -> True) (vartype ch)
+          
+showFeel :: FEELexp -> String
+showFeel (FNullary (VS str))  = show str
+showFeel (FNullary (VN num))  = show num
+showFeel (FNullary (VB bool)) = toLower <$> show bool
+showFeel (FSection Feq  (VB rhs)) = "(x)=>x === "++ (toLower <$> show rhs)
+showFeel (FSection Feq  (VS rhs)) = "(x)=>x === "++ show rhs
+showFeel (FSection Feq  (VN rhs)) = "(x)=>x === "++ show rhs
+showFeel (FSection Flt  (VN rhs)) = "(x)=>x < "++show rhs
+showFeel (FSection Flte (VN rhs)) = "(x)=>x <="++show rhs
+showFeel (FSection Fgt  (VN rhs)) = "(x)=>x > "++show rhs
+showFeel (FSection Fgte (VN rhs)) = "(x)=>x >="++show rhs
+showFeel (FInRange lower upper)   = "(x)=>" ++ show lower ++ "<= x && x <= " ++ show upper
+showFeel (FFunction (FNF1 var))     = var
+showFeel (FFunction (FNF0 (VS str))) = "\"" ++ str ++ "\""
+showFeel (FFunction (FNF0 (VB bool))) = toLower <$> show bool
+showFeel (FFunction (FNF0 (VN num)))  = show num
+showFeel (FFunction (FNF3 lhs fnop2 rhs))  = "(" ++ showFeel (FFunction lhs) ++ showFNOp2 fnop2 ++ showFeel (FFunction rhs) ++ ")"
+showFeel  FAnything               = "undefined"
+
+showFNOp2 :: FNOp2 -> String
+showFNOp2 FNMul   = " * "
+showFNOp2 FNDiv   = " / "
+showFNOp2 FNPlus  = " + "
+showFNOp2 FNMinus = " - "
+showFNOp2 FNExp   = " ** "

--- a/languages/haskell/src/DMN/Translate/JS.hs
+++ b/languages/haskell/src/DMN/Translate/JS.hs
@@ -11,6 +11,7 @@ import Data.List
 import Data.Maybe
 import Data.Char
 import DMN.Types
+import DMN.Translate.FEELhelpers
 
 data JSOpts = JSOpts { propstyle :: Bool
                      , typescript :: Bool }
@@ -124,8 +125,8 @@ wrapParen myop xs
   | length xs  > 1 = "(" ++ intercalate myop xs ++ ")"
   | length xs == 1 = head xs
   | otherwise      = "null"
-wrapArray :: String -> [String] -> String
-wrapArray myop xs = "[" ++ intercalate myop xs ++ "]"
+--wrapArray :: String -> [String] -> String
+--wrapArray myop xs = "[" ++ intercalate myop xs ++ "]"
 
 nonBlankCols :: a -> [FEELexp] -> Maybe (a, [FEELexp])
 nonBlankCols chs dtrows = if dtrows /= [FAnything] then Just (chs, dtrows) else Nothing
@@ -165,39 +166,4 @@ feel2jsOut hp chs dtrow
      uncurry showFeels <$> zip
                              (filter ((DTCH_Out==).label) chs)
                              (row_outputs dtrow))
-  
-type ColPair = (ColHeader, [FEELexp])
 
-showFeels :: ColHeader -> [FEELexp] -> String
-showFeels ch fexps = "\"" ++ varname ch ++ "\":" ++ if squash
-                                                    then showFeel $ head fexps
-                                                    else wrapArray "," (showFeel <$> fexps)
-  where squash = maybe True (\case
-                                DMN_List _ -> False
-                                _          -> True) (vartype ch)
-          
-showFeel :: FEELexp -> String
-showFeel (FNullary (VS str))  = show str
-showFeel (FNullary (VN num))  = show num
-showFeel (FNullary (VB bool)) = toLower <$> show bool
-showFeel (FSection Feq  (VB rhs)) = "(x)=>x === "++ (toLower <$> show rhs)
-showFeel (FSection Feq  (VS rhs)) = "(x)=>x === "++ show rhs
-showFeel (FSection Feq  (VN rhs)) = "(x)=>x === "++ show rhs
-showFeel (FSection Flt  (VN rhs)) = "(x)=>x < "++show rhs
-showFeel (FSection Flte (VN rhs)) = "(x)=>x <="++show rhs
-showFeel (FSection Fgt  (VN rhs)) = "(x)=>x > "++show rhs
-showFeel (FSection Fgte (VN rhs)) = "(x)=>x >="++show rhs
-showFeel (FInRange lower upper)   = "(x)=>" ++ show lower ++ "<= x && x <= " ++ show upper
-showFeel (FFunction (FNF1 var))     = var
-showFeel (FFunction (FNF0 (VS str))) = "\"" ++ str ++ "\""
-showFeel (FFunction (FNF0 (VB bool))) = toLower <$> show bool
-showFeel (FFunction (FNF0 (VN num)))  = show num
-showFeel (FFunction (FNF3 lhs fnop2 rhs))  = "(" ++ showFeel (FFunction lhs) ++ showFNOp2 fnop2 ++ showFeel (FFunction rhs) ++ ")"
-showFeel  FAnything               = "undefined"
-
-showFNOp2 :: FNOp2 -> String
-showFNOp2 FNMul   = " * "
-showFNOp2 FNDiv   = " / "
-showFNOp2 FNPlus  = " + "
-showFNOp2 FNMinus = " - "
-showFNOp2 FNExp   = " ** "

--- a/languages/haskell/src/DMN/Translate/JS.hs
+++ b/languages/haskell/src/DMN/Translate/JS.hs
@@ -139,14 +139,14 @@ comment_headers = filter ((DTCH_Comment==).label)
 
 feel2jsIn :: String -> FEELexp -> String
 feel2jsIn lhs  FAnything = wrapParen "||" ["true",lhs]
-feel2jsIn lhs (FSection Feq (VB rhs))  = lhs ++ "===" ++ (toLower <$> show rhs)
-feel2jsIn lhs (FSection Feq (VN rhs))  = lhs ++ "===" ++ show rhs
-feel2jsIn lhs (FSection Feq (VS rhs))  = lhs ++ "===" ++ show rhs
-feel2jsIn lhs (FSection Flt  (VN rhs)) = lhs ++ " < "  ++ show rhs
-feel2jsIn lhs (FSection Flte (VN rhs)) = lhs ++ " <="  ++ show rhs
-feel2jsIn lhs (FSection Fgt  (VN rhs)) = lhs ++ " > "  ++ show rhs
-feel2jsIn lhs (FSection Fgte (VN rhs)) = lhs ++ " >="  ++ show rhs
-feel2jsIn lhs (FInRange lower upper)   = wrapParen " && " [show lower ++ "<=" ++ lhs, lhs ++ "<=" ++ show upper]
+feel2jsIn lhs (FSection Feq (VB rhs))  = lhs ++ showFNComp "ts" FNEq  ++ (toLower <$> show rhs)
+feel2jsIn lhs (FSection Feq (VN rhs))  = lhs ++ showFNComp "ts" FNEq  ++ show rhs
+feel2jsIn lhs (FSection Feq (VS rhs))  = lhs ++ showFNComp "ts" FNEq  ++ show rhs
+feel2jsIn lhs (FSection Flt  (VN rhs)) = lhs ++ showFNComp "ts" FNLt  ++ show rhs
+feel2jsIn lhs (FSection Flte (VN rhs)) = lhs ++ showFNComp "ts" FNLeq ++ show rhs
+feel2jsIn lhs (FSection Fgt  (VN rhs)) = lhs ++ showFNComp "ts" FNGt  ++ show rhs
+feel2jsIn lhs (FSection Fgte (VN rhs)) = lhs ++ showFNComp "ts" FNGeq ++ show rhs
+feel2jsIn lhs (FInRange lower upper)   = wrapParen (showFNLog "ts" FNAnd) [show lower ++ showFNComp "ts" FNLeq ++ lhs, lhs ++ showFNComp "ts" FNLeq ++ show upper]
 feel2jsIn lhs (FNullary rhs)           = feel2jsIn lhs (FSection Feq rhs)
 
 -- TODO:
@@ -163,7 +163,7 @@ feel2jsOut :: HitPolicy -> [ColHeader] -> DTrow -> (Maybe String, [String])
 feel2jsOut hp chs dtrow
   -- ("// one input column, allowing binary operators in output column(s)"
   = (Nothing, -- "toreturn[thiscolumn] = ..."
-     uncurry showFeels <$> zip
-                             (filter ((DTCH_Out==).label) chs)
-                             (row_outputs dtrow))
+     uncurry (showFeels "js") <$> zip
+                                    (filter ((DTCH_Out==).label) chs)
+                                    (row_outputs dtrow))
 

--- a/languages/haskell/src/DMN/Translate/PY.hs
+++ b/languages/haskell/src/DMN/Translate/PY.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE LambdaCase #-}
+-- Ignore these for now
+{-# OPTIONS_GHC -Wno-unused-matches #-}
+
+module DMN.Translate.PY where
+
+-- in a future iteration of this code, consider using http://hackage.haskell.org/package/js-good-parts
+
+import DMN.DecisionTable
+import Data.List
+import Data.Maybe
+import Data.Char
+import DMN.Types
+import DMN.Translate.FEELhelpers
+
+data PYOpts = PYOpts { propstyle :: Bool
+                     , typescript :: Bool }
+
+toPY :: PYOpts -> DecisionTable -> String
+-- https://github.com/faylang/fay/wiki
+toPY jsopts dt =
+  unlines $ ( --this section creates the function header
+             [ unwords $ concat [ mkFunction (tableName dt)                                 
+             , mkArguments jsopts (header dt)
+                                , [ ":"]
+                                ] ] 
+             -- this section creates the relevant function body
+             ++ zipWith (\if_ dtrow -> mkIf jsopts (hitpolicy dt) if_ (header dt) dtrow) elsif (datarows dt)             
+            )   
+  where
+    elsif = "if" : repeat ( case hitpolicy dt of
+                               HP_Unique    -> "elif"
+                               HP_First     -> "elif"
+                               HP_Priority  -> "elif"
+                               HP_Collect _ -> "if"
+                               _            -> "if")
+  
+mkFunction tablename = [ "def", underscore tablename ]  -- helper function for function boilerplate 
+
+-- helper function for generating (arguments)
+mkArguments :: PYOpts -> [ColHeader] -> [String]
+mkArguments pyopts chs = ["(", intercalate ", " (mkArgument pyopts <$> input_headers chs), ")"]
+
+-- helper function for generating individual arguments that go into (args)
+mkArgument :: PYOpts -> ColHeader -> String
+mkArgument pyopts ch = var_name ch ++ maybe "" (if typescript pyopts then (" : " ++) . type2py else const "") (vartype ch) 
+
+type2py :: DMNType -> String
+type2py DMN_String    = "str"
+type2py DMN_Number    = "float"
+type2py DMN_Boolean   = "bool"
+type2py (DMN_List x)  = type2py x ++ "[]"
+
+mkIf :: PYOpts -> HitPolicy -> String -> [ColHeader] -> DTrow -> String
+mkIf jsopts hp ifword chs dtrow =
+  let conditions = uncurry (fexp2js jsopts) <$> catMaybes ( zipWith nonBlankCols (input_headers chs) (row_inputs dtrow) )
+  in
+    "  " ++ ifword ++ " (" ++
+    (if not (null conditions)
+     then intercalate " && " conditions
+     else "\"default\"") -- TODO: tweak ifword to allow just an "else" here, rather than exploiting the truthiness of JS
+    ++ "): # " ++
+    maybe "cont'd" show (row_number dtrow) ++ "\n" ++
+    (let feelout = feel2pyOut hp chs dtrow
+         standard = maybe "" (\infra -> "    " ++ infra ++ "\n") (fst feelout) ++ "    return {" ++ intercalate ", " (snd feelout) ++ "};"
+     in
+     case hp of
+       HP_Unique    -> standard
+       HP_Any       -> standard
+       HP_Collect _ -> standard
+       HP_First     -> standard
+       HP_Priority  -> standard
+       HP_OutputOrder -> standard
+       HP_RuleOrder -> standard
+       HP_Aggregate -> standard
+    )
+    ++ "\n"
+    ++ annotationsAsComments chs dtrow
+
+-- if the row has multiple annotation columns, show the varname of the column header.
+-- if there is only one visible annotation column, hide the varname of the column header.
+annotationsAsComments :: [ColHeader] -> DTrow -> String
+annotationsAsComments chs dtrow =
+  let prefixedComments = catMaybes $ zipWith (\cheader commentcol -> ((varname cheader ++ ": ") ++) <$> commentcol) (comment_headers chs) (row_comments dtrow)
+      unprefixed = catMaybes $ row_comments dtrow
+  in
+  unlines $ ("    # "++) <$> (if length unprefixed > 1 then prefixedComments else unprefixed)
+
+fexp2js :: PYOpts -> ColHeader -> [FEELexp] -> String
+fexp2js jsopts ch fexps = wrapParen " || " (feel2pyIn ( showVarname jsopts ch) <$> fexps)
+
+showVarname :: PYOpts -> ColHeader -> String
+showVarname jsopts ch
+  | propstyle jsopts = "props[\"" ++ varname ch ++ "\"]"
+  | otherwise        = var_name ch
+               
+wrapParen :: String -> [String] -> String
+wrapParen myop xs
+  | length xs  > 1 = "(" ++ intercalate myop xs ++ ")"
+  | length xs == 1 = head xs
+  | otherwise      = "null"
+wrapArray :: String -> [String] -> String
+wrapArray myop xs = "[" ++ intercalate myop xs ++ "]"
+
+nonBlankCols :: a -> [FEELexp] -> Maybe (a, [FEELexp])
+nonBlankCols chs dtrows = if dtrows /= [FAnything] then Just (chs, dtrows) else Nothing
+
+input_headers :: [ColHeader] -> [ColHeader]
+input_headers   = filter ((DTCH_In==).label)
+
+comment_headers :: [ColHeader] -> [ColHeader]
+comment_headers = filter ((DTCH_Comment==).label)
+
+capitalize :: String -> String
+capitalize [] = []
+capitalize (x:xs) = toUpper x : xs
+
+feel2pyIn :: String -> FEELexp -> String
+feel2pyIn lhs  FAnything = wrapParen "||" ["True",lhs]
+feel2pyIn lhs (FSection Feq (VB rhs))  = lhs ++ "==" ++ capitalize (toLower <$> show rhs)
+feel2pyIn lhs (FSection Feq (VN rhs))  = lhs ++ "==" ++ show rhs
+feel2pyIn lhs (FSection Feq (VS rhs))  = lhs ++ "==" ++ show rhs
+feel2pyIn lhs (FSection Flt  (VN rhs)) = lhs ++ " < "  ++ show rhs
+feel2pyIn lhs (FSection Flte (VN rhs)) = lhs ++ " <="  ++ show rhs
+feel2pyIn lhs (FSection Fgt  (VN rhs)) = lhs ++ " > "  ++ show rhs
+feel2pyIn lhs (FSection Fgte (VN rhs)) = lhs ++ " >="  ++ show rhs
+feel2pyIn lhs (FInRange lower upper)   = wrapParen " && " [show lower ++ "<=" ++ lhs, lhs ++ "<=" ++ show upper]
+feel2pyIn lhs (FNullary rhs)           = feel2pyIn lhs (FSection Feq rhs)
+
+-- TODO:
+-- let's extend FEEL with support for PCRE lol
+
+-- if there's a single output column then we just return that value
+-- if there are multiple output columns then we construct an object with multiple properties and return the object.
+
+-- we could treat each output column as a lambda with access to the input namespace.
+-- if there's only one input column, then we honour sections by returning the boolean result of operating against the unnamed input
+-- if there are multiple input columns then we require explicit use of the input column varname
+
+feel2pyOut :: HitPolicy -> [ColHeader] -> DTrow -> (Maybe String, [String])
+feel2pyOut hp chs dtrow
+  -- ("// one input column, allowing binary operators in output column(s)"
+  = (Nothing, -- "toreturn[thiscolumn] = ..."
+     uncurry showFeels <$> zip
+                             (filter ((DTCH_Out==).label) chs)
+                             (row_outputs dtrow))

--- a/languages/haskell/src/DMN/Translate/PY.hs
+++ b/languages/haskell/src/DMN/Translate/PY.hs
@@ -57,7 +57,7 @@ mkIf jsopts hp ifword chs dtrow =
   in
     "  " ++ ifword ++ " (" ++
     (if not (null conditions)
-     then intercalate " && " conditions
+     then intercalate " and " conditions
      else "\"default\"") -- TODO: tweak ifword to allow just an "else" here, rather than exploiting the truthiness of JS
     ++ "): # " ++
     maybe "cont'd" show (row_number dtrow) ++ "\n" ++
@@ -87,7 +87,7 @@ annotationsAsComments chs dtrow =
   unlines $ ("    # "++) <$> (if length unprefixed > 1 then prefixedComments else unprefixed)
 
 fexp2js :: PYOpts -> ColHeader -> [FEELexp] -> String
-fexp2js jsopts ch fexps = wrapParen " || " (feel2pyIn ( showVarname jsopts ch) <$> fexps)
+fexp2js jsopts ch fexps = wrapParen " or " (feel2pyIn ( showVarname jsopts ch) <$> fexps)
 
 showVarname :: PYOpts -> ColHeader -> String
 showVarname jsopts ch
@@ -116,7 +116,7 @@ capitalize [] = []
 capitalize (x:xs) = toUpper x : xs
 
 feel2pyIn :: String -> FEELexp -> String
-feel2pyIn lhs  FAnything = wrapParen "||" ["True",lhs]
+feel2pyIn lhs  FAnything = wrapParen "or" ["True",lhs]
 feel2pyIn lhs (FSection Feq (VB rhs))  = lhs ++ "==" ++ capitalize (toLower <$> show rhs)
 feel2pyIn lhs (FSection Feq (VN rhs))  = lhs ++ "==" ++ show rhs
 feel2pyIn lhs (FSection Feq (VS rhs))  = lhs ++ "==" ++ show rhs
@@ -124,7 +124,7 @@ feel2pyIn lhs (FSection Flt  (VN rhs)) = lhs ++ " < "  ++ show rhs
 feel2pyIn lhs (FSection Flte (VN rhs)) = lhs ++ " <="  ++ show rhs
 feel2pyIn lhs (FSection Fgt  (VN rhs)) = lhs ++ " > "  ++ show rhs
 feel2pyIn lhs (FSection Fgte (VN rhs)) = lhs ++ " >="  ++ show rhs
-feel2pyIn lhs (FInRange lower upper)   = wrapParen " && " [show lower ++ "<=" ++ lhs, lhs ++ "<=" ++ show upper]
+feel2pyIn lhs (FInRange lower upper)   = wrapParen " and " [show lower ++ "<=" ++ lhs, lhs ++ "<=" ++ show upper]
 feel2pyIn lhs (FNullary rhs)           = feel2pyIn lhs (FSection Feq rhs)
 
 -- TODO:

--- a/languages/haskell/src/DMN/Types.hs
+++ b/languages/haskell/src/DMN/Types.hs
@@ -140,7 +140,22 @@ data FNOp2 = FNMul
            | FNPlus
            | FNMinus
            | FNExp
-             deriving (Show, Eq)
+           deriving (Show, Eq)
+
+-- Logical operators (ALF: I'm not sure how i feel about this, when it comes to generating the lambda syntax in FEELhelpers.hs) 
+data FNLog = FNNot
+           | FNAnd
+           | FNOr
+           deriving (Show, Eq)
+
+-- Comparison Operators (ALF: I'm not sure how i feel about this, when it comes to generating the lambda syntax in FEELhelpers.hs) 
+data FNComp = FNEq
+            | FNNeq
+            | FNLt
+            | FNLeq
+            | FNGt
+            | FNGeq
+            deriving (Show, Eq)
 
 -- will need some pickle/unpickle infrastructure later
 data DMNVal = VS String


### PR DESCRIPTION
I made added a "PY.hs", extracted the FEEL functions into "FEELhelpers.hs" file to be used by both "JS.hs" & "PY.hs", and made some changes to the "app/Main.hs" and "app/Options.hs" files to enable python output. PY.hs is largely similar to JS.hs, except that functionality relating to typescript output is removed.

Currently it produces the appropriate python functions for the various tables within the README.md in the root folder. 

Would appreciate any feedback, as well as further direction. 