### PR TITLE
fix(xml): make the DMN 1.3 reader conformant, and make failure visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Latitude
+
+Per the author: dmnmd was written in a matter of weeks and **has never run in anger**. Bugs and
+bitrot are expected rather than surprising, and rearchitecting, redesigning and refactoring are
+explicitly welcome — do not contort a fix to preserve an existing shape that was never load-bearing.
+Fix root causes rather than patching symptoms.
+
+Two things this does *not* license, both from `BUILD-SPEC-dmnmd-extensions.md` §6: do not extend the
+**markdown format** speculatively (every extension must survive "would a lawyer still recognise this
+as a table?"), and this is not becoming a general DMN implementation. The latitude is about the
+implementation, not the language surface.
+
 ## What this is
 
 `dmnmd` is a CLI that reads DMN decision tables written as Markdown pipe tables and
@@ -125,13 +137,48 @@ the hand-written `test/golden/miles-card.l4`. Without that binary those examples
 regression. `l4 run` exits 0 even on a failed assertion, so the test greps stdout for
 `assertion satisfied` / `assertion failed`.
 
+## Diagnostics and exit status
+
+One rule governs both readers:
+
+> Anything we parse but do not yet honour must produce a loud, located diagnostic. Never
+> silently discard. Accepting input and quietly giving a different answer is strictly worse
+> than rejecting it.
+
+So `DMN.XML.XmlToDmnmd` returns `([Diagnostic], [DecisionTable])` rather than calling
+`error`. A `Warning` means something was dropped and says what (`<defaultOutputEntry>`, the
+`<annotation>` column names, a cell that is not a plain FEEL literal). An `Error` means a
+table could not be represented faithfully — a temporal `typeRef`, a rule whose entry count
+disagrees with the column count, a cell that cannot be built at the column's type — and
+that table is **not emitted**, because a table that can never match, or one whose rules have
+been silently widened, is a wrong answer that exits 0.
+
+The exit status answers exactly one question: *did something we were asked to read fail to
+read?*
+
+| input | status |
+|---|---|
+| valid DMN 1.3 with decision tables | 0 |
+| valid DMN 1.3 with no `<decision>` (`test/simple.dmn`) | 0 |
+| markdown with decision tables | 0 |
+| markdown with no decision tables — prose, or prose pipe tables (`test/golden/README.md`) | 0 |
+| malformed XML, or DMN 1.1/1.2 | 1 |
+| a table refused by the converter | 1 |
+| markdown where *some* tables parsed and others did not | 1, and nothing is emitted |
+
+A pipe table whose top-left cell is not a hit policy is prose, not a broken decision table:
+`ParseMarkdown.isDecisionTable` asks `parseHitPolicy` itself, skips the chunk, and says so
+on stderr as a `note:`. That is why a README full of documentation tables exits 0.
+
 ## Known-broken, don't be surprised
 
 `BUILD-SPEC-dmnmd-extensions.md` §1 records probes against the current tree:
 
-- **XML is aspirational.** `--from=xml` parses but imports 0 tables; `--to=xml` is not
-  implemented at all, despite `Xml` existing in `FileFormat` and `DMN.XML.*` existing in
-  the library. Treat any claim that dmnmd "supports DMN XML" as unverified.
+- **`--from=xml` reads DMN 1.3 only; `--to=xml` is not implemented at all**, despite `Xml`
+  existing in `FileFormat`. The reader is deliberately strict — an element or attribute the
+  vendored `xsd/DMN13.xsd` does not allow in that position is an error, and a DMN 1.1/1.2
+  document is refused by namespace with a message naming the version. Fixtures live in
+  `test/dmn13/`; its README says which refusal each one exercises.
 - **Multi-table Markdown works — `test/safe.md` is a bad fixture, not a chunking limit.**
   Its file-level failure is a **missing final newline** (the last byte is `|`); append one
   and `grepMarkdown` succeeds and 3 of its 13 tables import. Also, the reported position is
@@ -140,8 +187,6 @@ regression. `l4 run` exits 0 even on a failed assertion, so the test greps stdou
   parser some lines earlier. **Check for a final newline before trusting a `grepMarkdown`
   position.** The 10 tables that still fail after the fix are one-column tables that the
   grammar has no construct for; that is a separate, open gap.
-- The `~/.local/bin/dmnmd` shim on this machine is broken (`libpcre.1.dylib` not loaded);
-  run the cabal/stack build output directly.
 - **CI was red from 2025-06-29 until the `feat/translate-l4` CI fixes.** Two stacked
   causes, both environmental: the workflow never installed `libpcre3-dev`/`pkg-config` (so
   `regex-pcre` failed to configure before any project code compiled), and the deprecated

--- a/languages/haskell/app/Main.hs
+++ b/languages/haskell/app/Main.hs
@@ -10,7 +10,8 @@ import System.IO
       openFile,
       stdout,
       IOMode(WriteMode) )
-import Control.Monad ( when )
+import Control.Monad ( when, unless )
+import System.Exit ( exitFailure )
 import Data.List.Split (splitOn)
 import Data.List (intercalate, nub)
 
@@ -34,8 +35,8 @@ import DMN.Translate.JS ( toJS, JSOpts(JSOpts) )
 import DMN.Translate.PY ( toPY, PYOpts(PYOpts) )
 import DMN.Translate.L4 ( toL4, L4Opts(..), defaultL4Opts )
 import DMN.Translate.FEELhelpers ( showFeels )
-import DMN.XML.ParseDMN (parseDMN)
-import DMN.XML.XmlToDmnmd (convertAll)
+import DMN.XML.ParseDMN (parseDMNEither)
+import DMN.XML.XmlToDmnmd (convertAll, renderDiagnostic, isError)
 
 import Options
     ( ArgOptions(propstyle, verbose, out, pick, query, informat, input,
@@ -118,21 +119,53 @@ crash :: String -> a
 crash = errorWithoutStackTrace
 
 -- | initial parse of input tables. at present the emphasis is on markdown.
+--
+-- The exit status answers exactly one question: did something we were asked to
+-- read fail to read?
+--
+-- * a decision table that did not parse, or a DMN document that did not
+--   unpickle, or a table we refused to convert — nonzero, including when other
+--   tables in the same file were fine. A partial answer presented as a whole
+--   one is the failure mode this is here to prevent.
+-- * a well-formed file that simply contains no decision tables — zero. Prose
+--   markdown, and DMN with no @<decision>@, are legitimate inputs.
 parseTables :: ArgOptions -> IO [DecisionTable]
 parseTables opts = case informat opts of
-  Md -> parseMarkdown opts
+  Md -> do
+    (errs, tables) <- parseMarkdown opts
+    unless (null errs) $ do
+      mapM_ (hPutStrLn stderr . ("error: " ++)) errs
+      hPutStrLn stderr $
+        "dmnmd: " ++ show (length errs) ++ " decision table(s) in "
+          ++ intercalate ", " (input opts) ++ " could not be read"
+          ++ (if null tables then "" else "; refusing to emit the "
+                ++ show (length tables) ++ " that could, because partial output is"
+                ++ " indistinguishable from complete output.")
+      exitFailure
+    pure tables
   Xml -> parseDmnXml opts
   x -> crash $ "Unsupported input format: " ++ show x
              ++ ".\nSupported formats are: 'md' and 'xml'"
 
--- | Not sure if this is actually functional.
+-- | Read DMN XML. An unreadable document is fatal, not an empty table list.
 parseDmnXml :: ArgOptions -> IO [DecisionTable]
 parseDmnXml opts = do
   fileName <- case input opts of
     [fn] -> pure fn
     _ -> crash "Xml currently only supports a single file"
 
-  convertAll <$> parseDMN fileName
+  parsed <- parseDMNEither fileName
+  case parsed of
+    Left err -> crash err
+    Right defs -> do
+      let (diags, tables) = convertAll defs
+      mapM_ (hPutStrLn stderr . (\d -> fileName ++ ": " ++ renderDiagnostic d)) diags
+      when (any isError diags) $ do
+        hPutStrLn stderr $
+          "dmnmd: " ++ fileName ++ ": one or more decision tables were refused"
+            ++ " (see the errors above); nothing was emitted for them."
+        exitFailure
+      pure tables
 
 -- | Transpile decision table to outpu tformats.
 -- This is not quite finished; in future refactor this over to JS.hs

--- a/languages/haskell/app/ParseMarkdown.hs
+++ b/languages/haskell/app/ParseMarkdown.hs
@@ -10,11 +10,13 @@ import Data.Maybe ( catMaybes, fromMaybe )
 
 -- import Debug.Trace
 
+import Data.Either (isRight)
+
 import DMN.Types ( DecisionTable )
-import DMN.ParseTable ( parseTable )
+import DMN.ParseTable ( parseTable, parseHitPolicy, pipeSeparator )
 
 import Text.Megaparsec
-    ( MonadParsec(try, eof), satisfy, manyTill, many, (<?>), (<|>) )
+    ( MonadParsec(try, eof), takeRest, satisfy, manyTill, many, (<?>), (<|>) )
 import Text.Megaparsec.Char ( char )
 import DMN.ParsingUtils
     ( Parser,
@@ -30,23 +32,30 @@ import DMN.ParsingUtils
 import qualified Data.Text as T
 
 import Options ( ArgOptions(input, verbose) )
-import Data.Foldable (Foldable(toList))
-
--- | monadic concatMap.
--- TODO: Use ListT or this thing
-concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
-concatMapM f xs = fmap concat $ mapM f xs
 
 -- | parse input markdown file.
-parseMarkdown :: ArgOptions -> IO [DecisionTable]
+--
+-- Returns the parse errors alongside the tables. They used to go to stderr and
+-- nowhere else, so a file that failed to parse was indistinguishable from a file
+-- with nothing in it, and @dmnmd@ exited 0 either way. Printing them is now the
+-- caller's job — this function printing them too is what made every failure
+-- appear twice.
+--
+-- A returned error means a decision table did not parse. It does not mean "no
+-- decision tables here": a prose document, with or without pipe tables in it,
+-- is a perfectly good input that happens to contain nothing to transpile, and
+-- comes back as @([], [])@.
+parseMarkdown :: ArgOptions -> IO ([String], [DecisionTable])
 parseMarkdown opts1 = do
   let infiles = input opts1
-  mydtchunks <- concatMapM (fileChunks opts1) (zip [1..] infiles)
-  mydtables <- concatMapM (parseChunk opts1) mydtchunks
-  return mydtables
+  chunkResults <- mapM (fileChunks opts1) (zip [1..] infiles)
+  let (chunkErrs, mydtchunks) = (concatMap fst chunkResults, concatMap snd chunkResults)
+  tableResults <- mapM (parseChunk opts1) mydtchunks
+  let (tableErrs, mydtables) = (concatMap fst tableResults, concatMap snd tableResults)
+  return (chunkErrs ++ tableErrs, mydtables)
 
   where
-    fileChunks :: ArgOptions -> (Int, FilePath) -> IO InputChunks
+    fileChunks :: ArgOptions -> (Int, FilePath) -> IO ([String], [(FilePath, InputChunk)])
     fileChunks opts (inum,infile) = do
       mylog opts $ "* opening file: " ++ infile
       -- NOTE: Lazy IO
@@ -54,9 +63,10 @@ parseMarkdown opts1 = do
       inlines <- if infile == "-" then getContents else readFile infile
       let rawchunksEither = parseOnly (grepMarkdown ("f"++show inum) <?> "grepMarkdown") (T.pack inlines)
 
-      whenLeft rawchunksEither 
-        (\errstr -> myerr opts $ "** parser failure in grepMarkdown: " ++ errstr)
-      return $ either (const []) id rawchunksEither
+      case rawchunksEither of
+        Left errstr ->
+          pure ([infile ++ ": parser failure in grepMarkdown: " ++ errstr], [])
+        Right chunks -> pure ([], [(infile, c) | c <- chunks])
 
     myerr :: ArgOptions -> String -> IO ()
     myerr _ = hPutStrLn stderr
@@ -64,24 +74,47 @@ parseMarkdown opts1 = do
     mylog :: ArgOptions -> String -> IO ()
     mylog opts msg = when (verbose opts) $ myerr opts msg
 
-    parseChunk :: ArgOptions -> InputChunk -> IO [DecisionTable]
-    parseChunk opts mychunk
-     | chunkLines mychunk == ["|]"] = pure [] -- special case, sometimes |] closes a quasiquotation block
+    parseChunk :: ArgOptions -> (FilePath, InputChunk) -> IO ([String], [DecisionTable])
+    parseChunk opts (infile, mychunk)
+     | chunkLines mychunk == ["|]"] = pure ([], []) -- special case, sometimes |] closes a quasiquotation block
+     -- A pipe table whose top-left cell is not a hit policy is not a decision
+     -- table; markdown files are full of ordinary prose tables. Skipping one is
+     -- not an error — but it is not silent either, or a typo'd hit policy would
+     -- make a real table vanish without a word.
+     | not (isDecisionTable mychunk) = do
+         myerr opts $ "note: " ++ infile ++ ": skipping the pipe table under "
+           ++ show (chunkName mychunk)
+           ++ ": its top-left cell is not a DMN hit policy (one of U A P F O R C),"
+           ++ " so this is prose rather than a decision table."
+         pure ([], [])
      | otherwise = do
       let parseResult = parseOnly (parseTable (chunkName mychunk) <?> "parseTable")
             $ T.pack $ unlines $ chunkLines mychunk
-      let printParseError myPTfail =
-            myerr opts $
-              "** failed to parse table " ++ chunkName mychunk ++ "   :ERROR:\nat " ++ myPTfail
+      case parseResult of
+        Left myPTfail ->
+          pure ([infile ++ ": failed to parse table " ++ chunkName mychunk ++ " at " ++ myPTfail], [])
+        Right t -> pure ([], [t])
 
-      whenLeft parseResult printParseError
-      pure $ toList parseResult
-
-whenLeft :: Monad m => Either a b -> (a -> m ()) -> m ()
-whenLeft val onLeft =
-      case val of
-        Left e -> onLeft e
-        Right _ -> return ()
+-- | Does this chunk claim to be a decision table?
+--
+-- Asked of the real parser, not of a lookalike: the top-left cell of a dmnmd
+-- decision table is its hit policy, so we run 'parseHitPolicy' at exactly the
+-- position 'parseHeaderRow' would. Nothing here inspects characters by hand.
+-- | Is this pipe-table chunk a decision table, or prose that happens to be tabular?
+--
+-- The test is the FIRST TWO TOKENS OF 'parseHeaderRow' ITSELF — @pipeSeparator@,
+-- @parseHitPolicy@, @pipeSeparator@ — so a chunk is classified by the real grammar
+-- rather than by a proxy for it. The closing 'pipeSeparator' is the load-bearing
+-- part: 'parseHitPolicy' consumes a SINGLE character, so without it the test
+-- accepts any first cell that merely STARTS with a hit-policy letter, and
+-- @| file | role | provenance |@ (a documentation table in test/golden/README.md)
+-- is read as an @F@ table on the \"f\" of \"file\".
+isDecisionTable :: InputChunk -> Bool
+isDecisionTable mychunk = case chunkLines mychunk of
+  (firstline : _) ->
+    isRight $ parseOnly (pipeSeparator *> parseHitPolicy <* pipeSeparator <* takeRest)
+                        (T.pack firstline)
+  [] -> False
 
 -- * parsing support
 -- | the markdown parser deals with InputChunks, which tracks the chunk name and lines
@@ -95,9 +128,14 @@ data InputChunk = InputChunk
 -- in future, consider grabbing the tables out of Pandoc -- maybe this would be better off as a JSON filter?
 
 -- | look for relevant table sections in the markdown file
+--
+-- @many@, not @many1@: a markdown file with no pipe tables in it at all is a
+-- well-formed document that happens to contain nothing for us, not a parse
+-- failure. Requiring at least one table is what made every prose file in this
+-- repo exit 1.
 grepMarkdown :: String -> Parser InputChunks
 grepMarkdown defaultName = do
-  mytables <- many1 (try (grepTable defaultName) <?> "grepTable")
+  mytables <- many (try (grepTable defaultName) <?> "grepTable")
   (many irrelevantLine >> eof)
   return $ catMaybes mytables
 

--- a/languages/haskell/src/DMN/DecisionTable.hs
+++ b/languages/haskell/src/DMN/DecisionTable.hs
@@ -12,6 +12,7 @@ import Data.List.Split ( splitOn )
 import Data.Maybe ( catMaybes, fromJust )
 import Text.Regex.PCRE ( (=~) )
 import Data.Char (toLower)
+import Text.Read (readMaybe)
 import Debug.Trace ( trace )
 import qualified Data.Text as T
 import qualified Data.Map as Map
@@ -117,9 +118,19 @@ fNEval symtab (FNF3 fnf1 fnop2 fnf3) = let lhs = fromVN (fNEval symtab fnf1)
                                        in VN result
 
 mkFs :: Maybe DMNType -> String -> [FEELexp]
-mkFs dmntype args = do
-  arg <- trim <$> splitOn "," args
-  return (mkF dmntype arg)
+mkFs dmntype args = either error id (mkFsEither dmntype args)
+
+-- | 'mkFs' as a total function.
+--
+-- The markdown reader is happy to die on a malformed cell: it has already told
+-- the user which file and table it was reading. The XML reader is not — it has
+-- to name the table, column and rule, and refuse just that table. So the real
+-- work lives in 'mkFEither' and 'mkF' is the @error@-ing wrapper, which keeps
+-- the markdown path byte-for-byte as it was while giving the XML path something
+-- it can report on. Do not reintroduce a second copy of these guards elsewhere:
+-- a validator that drifts from the constructor is worse than no validator.
+mkFsEither :: Maybe DMNType -> String -> Either String [FEELexp]
+mkFsEither dmntype args = traverse (mkFEither dmntype) (trim <$> splitOn "," args)
 
 
 -- TODO: add a state monad to allow type inference to span all input rows;
@@ -129,41 +140,53 @@ mkFs dmntype args = do
 -- maybe we use a multi-pass strategy ... where we allow the cells to remain untyped ... and then we review the entire table
 -- after it's been fully parsed once.
 mkF :: Maybe DMNType -> String -> FEELexp
-mkF _ ""  = FAnything
-mkF _ "_" = FAnything
-mkF _ "-" = FAnything
+mkF dmntype arg = either error id (mkFEither dmntype arg)
+
+-- | The single definition of "what does this cell mean, given this column type".
+--
+-- Every failure is a 'Left' carrying a message that names the offending text;
+-- 'mkF' turns those into @error@ (unchanged markdown behaviour), the XML reader
+-- turns them into a located diagnostic. In particular the numeric literals go
+-- through 'readMaybe', so a Number column holding @not("Fall"@ no longer dies
+-- with a bare @Prelude.read: no parse@.
+mkFEither :: Maybe DMNType -> String -> Either String FEELexp
+mkFEither _ ""  = Right FAnything
+mkFEither _ "_" = Right FAnything
+mkFEither _ "-" = Right FAnything
 -- in a numeric column, an FFunction is detected by the presence of an numeric operator
-mkF t@(Just (DMN_List _)) x  = mkF (baseType t) x
-mkF Nothing  arg1 = -- trace ("mkF Nothing shouldn't happen -- type inference should have found some type for this column. coercing to string: " ++ arg1)
-  FNullary (VS (trim arg1))
+mkFEither t@(Just (DMN_List _)) x  = mkFEither (baseType t) x
+mkFEither Nothing  arg1 = -- trace ("mkF Nothing shouldn't happen -- type inference should have found some type for this column. coercing to string: " ++ arg1)
+  Right (FNullary (VS (trim arg1)))
 
 -- strings are tricky because they could be FEEL expression variable names like "Dish Name"
 -- or just literal strings like "Lentil Soup"
 
-mkF (Just DMN_String)  arg1 = FNullary (VS (trim arg1))
-mkF (Just DMN_Boolean) arg1 = FNullary (mkVB arg1)
+mkFEither (Just DMN_String)  arg1 = Right (FNullary (VS (trim arg1)))
+mkFEither (Just DMN_Boolean) arg1 = FNullary <$> mkVB arg1
   where
     mkVB arg
-      | (toLower <$> arg) `elem` ["true","yes","t","y","positive"] = VB True
-      | (toLower <$> arg) `elem` ["false","no","t","y","negative"] = VB False
-      | otherwise = error $  "unable to parse an alleged boolean: " ++ arg
-mkF (Just DMN_Number)  arg1
-  | not (null ("+-*/" `intersect` arg2)) = either (\msg -> error $ "error: parsing suspected function expression " ++ arg2 ++ ": " ++ msg) FFunction (parseOnly parseFNumFunction (T.pack arg2))
-  | "<=" `isPrefixOf` arg2 = FSection Flte (mkVN $ trim $ drop 2 arg2)
-  | "<"  `isPrefixOf` arg2 = FSection Flt  (mkVN $ trim $ drop 1 arg2)
-  | ">=" `isPrefixOf` arg2 = FSection Fgte (mkVN $ trim $ drop 2 arg2)
-  | ">"  `isPrefixOf` arg2 = FSection Fgt  (mkVN $ trim $ drop 1 arg2)
-  | "<=" `isSuffixOf` arg2 = FSection Fgt  (mkVN $ trim $ Prelude.take (length arg2 - 2) arg2)
-  | "<"  `isSuffixOf` arg2 = FSection Fgte (mkVN $ trim $ Prelude.take (length arg2 - 1) arg2)
-  | ">=" `isSuffixOf` arg2 = FSection Flt  (mkVN $ trim $ Prelude.take (length arg2 - 2) arg2)
+      | (toLower <$> arg) `elem` ["true","yes","t","y","positive"] = Right (VB True)
+      | (toLower <$> arg) `elem` ["false","no","t","y","negative"] = Right (VB False)
+      | otherwise = Left $  "unable to parse an alleged boolean: " ++ arg
+mkFEither (Just DMN_Number)  arg1
+  | not (null ("+-*/" `intersect` arg2)) = either (\msg -> Left $ "error: parsing suspected function expression " ++ arg2 ++ ": " ++ msg) (Right . FFunction) (parseOnly parseFNumFunction (T.pack arg2))
+  | "<=" `isPrefixOf` arg2 = FSection Flte <$> (mkVN $ trim $ drop 2 arg2)
+  | "<"  `isPrefixOf` arg2 = FSection Flt  <$> (mkVN $ trim $ drop 1 arg2)
+  | ">=" `isPrefixOf` arg2 = FSection Fgte <$> (mkVN $ trim $ drop 2 arg2)
+  | ">"  `isPrefixOf` arg2 = FSection Fgt  <$> (mkVN $ trim $ drop 1 arg2)
+  | "<=" `isSuffixOf` arg2 = FSection Fgt  <$> (mkVN $ trim $ Prelude.take (length arg2 - 2) arg2)
+  | "<"  `isSuffixOf` arg2 = FSection Fgte <$> (mkVN $ trim $ Prelude.take (length arg2 - 1) arg2)
+  | ">=" `isSuffixOf` arg2 = FSection Flt  <$> (mkVN $ trim $ Prelude.take (length arg2 - 2) arg2)
   | arg2 =~ "\\[\\s*(\\d+)\\s*\\.\\.\\s*(\\d+)\\s*\\]" :: Bool =
     let (_,_,_,bounds) = arg2 =~ "\\[\\s*(\\d+)\\s*\\.\\.\\s*(\\d+)\\s*\\]" :: (String,String,String,[String])
-    in FInRange ((read $ head bounds) :: Float) ((read $ bounds!!1) :: Float)
-  | "="  `isPrefixOf` arg2 = FSection Feq  (mkVN $ trim $ dropWhile    (=='=') arg2)
-  | "="  `isSuffixOf` arg2 = FSection Feq  (mkVN $ trim $ dropWhileEnd (=='=') arg2)
-  | otherwise              = FNullary      (mkVN $ trim                        arg2)
+    in Right (FInRange ((read $ head bounds) :: Float) ((read $ bounds!!1) :: Float))
+  | "="  `isPrefixOf` arg2 = FSection Feq  <$> (mkVN $ trim $ dropWhile    (=='=') arg2)
+  | "="  `isSuffixOf` arg2 = FSection Feq  <$> (mkVN $ trim $ dropWhileEnd (=='=') arg2)
+  | otherwise              = FNullary      <$> (mkVN $ trim                        arg2)
   where arg2 = trim arg1 -- probably extraneous
-        mkVN x = VN (read x :: Float)
+        mkVN x = maybe (Left $ "expected a number, but this column is typed Number and the cell reads " ++ show arg2)
+                       (Right . VN)
+                       (readMaybe x :: Maybe Float)
 
 fromVN :: DMNVal -> Float
 fromVN (VN n) = n

--- a/languages/haskell/src/DMN/XML/ParseDMN.hs
+++ b/languages/haskell/src/DMN/XML/ParseDMN.hs
@@ -21,6 +21,8 @@ import qualified DMN.Types as DT
 import DMN.XML.PickleHelpers
 import Text.XML.HXT.Core
 import Data.Void (Void)
+import Data.Maybe (listToMaybe)
+import Data.List (intercalate, nub)
 
 getEx1 :: IO [XmlTree]
 getEx1 = runX $ readDocument [] "test/simulation.dmn"
@@ -30,9 +32,6 @@ getEx2 = do
   [ans] <- runX $ removeAllWhiteSpace <<< readDocument [withCheckNamespaces True] "test/simple.dmn"
   pure ans
 
-ignoreContent :: [String] -> PU a -> PU a
-ignoreContent name = xpFilterCont (none `when` foldl1 (<+>) (hasName <$> name))
-
 xmlns_dmn, xmlns_dmndi, xmlns_dc, xmlns_di, xmlns_camunda :: String
 xmlns_dmn = "https://www.omg.org/spec/DMN/20191111/MODEL/"
 xmlns_dmndi = "https://www.omg.org/spec/DMN/20191111/DMNDI/"
@@ -40,19 +39,100 @@ xmlns_dc = "http://www.omg.org/spec/DMN/20180521/DC/"
 xmlns_di = "http://www.omg.org/spec/DMN/20180521/DI/"
 xmlns_camunda = "http://camunda.org/schema/1.0/dmn"
 
+-- | Namespaces of the DMN releases we can recognise. Only 1.3 is readable; the
+-- others exist so that we can say /which/ version we are refusing rather than
+-- failing with a generic unpickling error.
+dmnVersionOfNamespace :: String -> Maybe String
+dmnVersionOfNamespace ns = lookup ns
+  [ ("http://www.omg.org/spec/DMN/20151101/dmn.xsd", "DMN 1.1")
+  , ("http://www.omg.org/spec/DMN/20180521/MODEL/",  "DMN 1.2")
+  , (xmlns_dmn,                                      "DMN 1.3")
+  ]
+
 xpDMNElem :: String -> AnIso' a b -> PU b -> PU a
 xpDMNElem name iso = xpElemNS xmlns_dmn "" name . wrapIso iso
 
 xpDMNDIElem :: String -> AnIso' a b -> PU b -> PU a
 xpDMNDIElem name iso = xpElemNS xmlns_dmndi "dmndi" name . wrapIso iso
 
-withNS :: PU a -> PU a
-withNS =
-  xpAddNSDecl "" xmlns_dmn
-    . xpAddNSDecl "dmndi" xmlns_dmndi
-    . xpAddNSDecl "dc" xmlns_dc
-    . xpAddNSDecl "di" xmlns_di
-    . xpFilterAttr (none `when` hasName "xmlns:camunda")
+-- * Schema-guided ignoring
+--
+-- The picklers below are deliberately strict: an element or attribute that the
+-- DMN 1.3 XSD does not allow in that position makes the whole document fail.
+-- The helpers here exist so that the things the XSD /does/ allow but dmnmd has
+-- no use for (diagram interchange, provenance, foreign extensions) can be
+-- consumed *in their schema position* instead of being waved through by a
+-- blanket filter.
+
+-- | Consume an attribute that the XSD declares here but dmnmd does not model,
+-- and throw its value away. Naming it explicitly keeps every *other* attribute
+-- an error.
+xpIgnoredAttr :: String -> PU a -> PU a
+xpIgnoredAttr name =
+  xpSeq' (xpWrap (const (), const Nothing) . xpOption $ xpAttr name xpText)
+
+xpIgnoredAttrs :: [String] -> PU a -> PU a
+xpIgnoredAttrs names p = foldr xpIgnoredAttr p names
+
+-- | Consume one child element in the DMN namespace, with whatever attributes
+-- and content it happens to carry, and throw it away. Only ever used at a
+-- position where the XSD permits that element.
+xpIgnoredElem :: String -> PU ()
+xpIgnoredElem name =
+  xpElemNS xmlns_dmn "" name . xpFilterAttr none . xpFilterCont none $ xpUnit
+
+-- | @minOccurs="0" maxOccurs="1"@ version of 'xpIgnoredElem'.
+xpIgnoredElemOpt :: String -> PU ()
+xpIgnoredElemOpt name =
+  xpWrap (const (), const Nothing) . xpOption $ xpIgnoredElem name
+
+-- | @minOccurs="0" maxOccurs="unbounded"@ over a substitution group: any run of
+-- children whose local names are in the given list.
+xpIgnoredElemsOf :: [String] -> PU ()
+xpIgnoredElemsOf [] = xpLift ()
+xpIgnoredElemsOf names =
+  xpWrap (const (), const []) . xpList . xpAlt (const 0) $ map xpIgnoredElem names
+
+xpIgnoredElems :: String -> PU ()
+xpIgnoredElems name = xpIgnoredElemsOf [name]
+
+-- | The two children every @tDMNElement@ may carry, in schema order:
+-- @<description>@ and @<extensionElements>@.
+--
+-- Both are dropped. @<description>@ is human-readable annotation that only
+-- 'Rule' makes use of (as a row comment), so 'Rule' parses it explicitly
+-- instead of using this. @<extensionElements>@ is declared
+-- @<xsd:any namespace="##other" processContents="lax"/>@ — the standard itself
+-- says a consumer may ignore it.
+xpDmnAnnotations :: PU ()
+xpDmnAnnotations =
+  xpWrap (const (), const ((), ())) $
+    xpPair (xpIgnoredElemOpt "description") (xpIgnoredElemOpt "extensionElements")
+
+-- | @<extensionElements>@ only, for elements whose @<description>@ we keep.
+xpExtensionElements :: PU ()
+xpExtensionElements = xpIgnoredElemOpt "extensionElements"
+
+-- | Attributes that are XML plumbing rather than DMN content, stripped from the
+-- whole tree before unpickling:
+--
+-- * namespace declarations (@xmlns@, @xmlns:foo@). Once HXT has resolved names
+--   these carry no information, and demanding a fixed set of them (as the old
+--   'xpAddNSDecl' chain did) rejected both minimal files and files carrying one
+--   extra unrelated declaration such as @xsi@.
+-- * attributes in a foreign namespace. @tDMNElement@ ends with
+--   @<xsd:anyAttribute namespace="##other" processContents="lax"/>@, so DMN
+--   itself sanctions ignoring these (@camunda:inputVariable@, @kie:*@ …).
+--
+-- Unprefixed attributes have no namespace and are therefore *not* touched: an
+-- unknown attribute in DMN's own vocabulary is still an error.
+stripIgnorableAttrs :: ArrowXml a => a XmlTree XmlTree
+stripIgnorableAttrs =
+    processTopDown (processAttrl (none `when` (isNsDecl <+> isForeignAttr)) `when` isElem)
+  where
+    isNsDecl      = hasNameWith isNameSpaceName
+    isForeignAttr = hasNameWith $ \qn ->
+      let uri = namespaceUri qn in not (null uri) && uri /= xmlns_dmn
 
 data Description = Description
   { description :: String
@@ -130,11 +210,13 @@ data DMNDI = DMNDI
 
 makePrisms ''DMNDI
 
+-- | Diagram interchange: geometry only, deliberately not modelled. The whole
+-- subtree (and any attributes on it) is discarded.
 instance XmlPickler DMNDI where
   xpickle =
     xpDMNDIElem "DMNDI" _DMNDI
-      -- . xpFilterAttr (hasName "id" <+> hasName "name")
-      . xpFilterCont none -- TODO
+      . xpFilterAttr none
+      . xpFilterCont none
       $ xpickle
 
 -- These can point to some input node (which is kind of useless) or to another table,
@@ -181,11 +263,14 @@ data InformationRequirement = InformationRequirement
 
 makePrisms ''InformationRequirement
 
+-- | @tInformationRequirement@: @description?@, @extensionElements?@, then
+-- exactly one of @requiredDecision@ / @requiredInput@.
 instance XmlPickler InformationRequirement where
   xpickle =
     xpDMNElem "informationRequirement" (_InformationRequirement . pairsIso)
+      . xpIgnoredAttr "label"
     $
-      xpPair xpickle (pcklReqInput xpickle)
+      xpPair xpickle (xpSeq' xpDmnAnnotations (pcklReqInput xpickle))
 
 {-
 	<xsd:simpleType name="tBuiltinAggregator">
@@ -279,6 +364,9 @@ data ColumnLabel = ColumnLabel
 
 makePrisms ''ColumnLabel
 
+-- | @tDMNElement/@label@. DMN 1.3 makes it optional everywhere (XSD line 29,
+-- @use="optional"@), so callers wrap this in 'xpOption'; requiring it here is
+-- what used to reject perfectly legal @<input>@ and @<output>@ clauses.
 instance XmlPickler ColumnLabel where
   xpickle = wrapIso _ColumnLabel $ xpAttr "label" xpText
 
@@ -303,8 +391,10 @@ data TExpr = TExpr
 
 makePrisms ''TExpr
 
+-- | @tExpression@'s attributes: @id@/@label@ (from @tDMNElement@) plus an
+-- optional @typeRef@. @label@ is consumed and dropped.
 instance XmlPickler TExpr where
-  xpickle = wrapIso _TExpr xpickle
+  xpickle = xpIgnoredAttr "label" . wrapIso _TExpr $ xpickle
 
 data ExpressionLanguage = ExpressionLanguage String -- xsd:anyURI
   deriving (Show, Eq)
@@ -322,8 +412,62 @@ data TLiteralExpression = TLiteralExpression
 
 makePrisms ''TLiteralExpression
 
+-- | @tLiteralExpression@: @description?@, @extensionElements?@, then a choice of
+-- @<text>@ or @<importedValues>@ (both optional). We model @<text>@; a literal
+-- expression backed by @<importedValues>@ is rejected rather than silently read
+-- as an empty expression.
 instance XmlPickler TLiteralExpression where
-  xpickle = wrapIso _TLiteralExpression xpickle
+  xpickle =
+    wrapIso _TLiteralExpression $
+      xpTriple
+        xpickle                                    -- TExpr: id/typeRef attrs
+        (xpOption xpickle)                         -- expressionLanguage attr
+        (xpSeq' xpDmnAnnotations (xpOption xpickle))  -- <text>?
+
+-- | @tUnaryTests@ (used by @<inputValues>@, @<outputValues>@, @<inputEntry>@).
+-- Same shape as a literal expression but @<text>@ is required.
+data UnaryTestsBody = UnaryTestsBody
+  { utExpr :: TExpr
+  , utExpressionLanguage :: Maybe ExpressionLanguage
+  , utText :: TextElement
+  }
+  deriving (Show, Eq)
+
+makePrisms ''UnaryTestsBody
+
+instance XmlPickler UnaryTestsBody where
+  xpickle =
+    wrapIso _UnaryTestsBody $
+      xpTriple xpickle (xpOption xpickle) (xpSeq' xpDmnAnnotations xpickle)
+
+-- | @tInputClause/inputValues@ — the declared domain of an input column.
+newtype InputValues = InputValues UnaryTestsBody
+  deriving (Show, Eq)
+
+makePrisms ''InputValues
+
+instance XmlPickler InputValues where
+  xpickle = xpDMNElem "inputValues" _InputValues xpickle
+
+-- | @tOutputClause/outputValues@ — the declared domain of an output column.
+-- Byte-identically unmodelled before this change, which is why a fix aimed only
+-- at @defaultOutputEntry@ would have left it broken.
+newtype OutputValues = OutputValues UnaryTestsBody
+  deriving (Show, Eq)
+
+makePrisms ''OutputValues
+
+instance XmlPickler OutputValues where
+  xpickle = xpDMNElem "outputValues" _OutputValues xpickle
+
+-- | @tOutputClause/defaultOutputEntry@ — the value taken when no rule matches.
+newtype DefaultOutputEntry = DefaultOutputEntry TLiteralExpression
+  deriving (Show, Eq)
+
+makePrisms ''DefaultOutputEntry
+
+instance XmlPickler DefaultOutputEntry where
+  xpickle = xpDMNElem "defaultOutputEntry" _DefaultOutputEntry xpickle
 
 data LiteralExpression = LiteralExpression TLiteralExpression
   deriving (Show, Eq)
@@ -346,10 +490,17 @@ makePrisms ''InputExpression
 instance XmlPickler InputExpression where
   xpickle = xpDMNElem "inputExpression" _InputExpression xpickle
 
+-- | @tInputClause@: @description?@, @extensionElements?@, @inputExpression@
+-- (required), @inputValues?@. Attributes @id@ and @label@ (both optional).
+--
+-- @camunda:inputVariable@ used to need a hand-written filter here; foreign
+-- attributes are now stripped tree-wide by 'stripIgnorableAttrs', which is what
+-- the XSD's @anyAttribute namespace="##other"@ actually calls for.
 data TableInput = TableInput
   { tinpName :: DmnCommon
-  , tinpLabel :: ColumnLabel
+  , tinpLabel :: Maybe ColumnLabel
   , tinpExpr :: InputExpression
+  , tinpValues :: Maybe InputValues
   }
   deriving (Show, Eq)
 
@@ -358,16 +509,22 @@ makePrisms ''TableInput
 instance XmlPickler TableInput where
   xpickle =
     xpDMNElem "input" _TableInput
-      -- . xpFilterAttr (hasName "id" <+> hasName "name" <+> hasName "label")
-      -- . xpFilterAttr (none `when` hasQName (mkQName xmlns_camunda "camunda" "inputVariable"))
-      . xpFilterAttr (none `when` hasName "camunda:inputVariable")
-      $ xpickle
+      $ xp4Tuple
+          xpickle
+          (xpOption xpickle)
+          (xpSeq' xpDmnAnnotations xpickle)
+          (xpOption xpickle)
 
--- tOutputClause in schema
+-- | @tOutputClause@: @description?@, @extensionElements?@, @outputValues?@,
+-- @defaultOutputEntry?@. Attributes @id@, @label@, @name@, @typeRef@ — all
+-- optional (XSD lines 326-339: neither @name@ nor @typeRef@ carries a @use=@,
+-- and @use="optional"@ is the default).
 data TableOutput = TableOutput
   { toutName :: DmnCommon
-  , toutLabel :: ColumnLabel -- Note: This is optional according to the schema, but that doesn't make much sense
-  , toutTypeRef :: TypeRef
+  , toutLabel :: Maybe ColumnLabel
+  , toutTypeRef :: Maybe TypeRef
+  , toutValues :: Maybe OutputValues
+  , toutDefault :: Maybe DefaultOutputEntry
   }
   deriving (Show, Eq)
 
@@ -376,8 +533,12 @@ makePrisms ''TableOutput
 instance XmlPickler TableOutput where
   xpickle =
     xpDMNElem "output" _TableOutput
-      -- . xpFilterCont none -- TODO: Need a test case
-      $ xpickle
+      $ xp5Tuple
+          xpickle
+          (xpOption xpickle)
+          (xpOption xpickle)
+          (xpSeq' xpDmnAnnotations (xpOption xpickle))
+          (xpOption xpickle)
 
 --- $> import Text.XML.HXT.Core
 
@@ -393,12 +554,12 @@ data InputEntry = InputEntry
 
 makePrisms ''InputEntry
 
+-- | @tUnaryTests@ in the @<inputEntry>@ position.
 instance XmlPickler InputEntry where
   xpickle =
     xpDMNElem "inputEntry" _InputEntry
-      -- . xpFilterAttr (hasName "id" <+> hasName "name")
-      -- . xpFilterCont none -- TODO
-      $ xpickle
+      . xpIgnoredAttrs ["label", "typeRef", "expressionLanguage"]
+      $ xpPair xpickle (xpSeq' xpDmnAnnotations xpickle)
 
 data OutputEntry = OutputEntry
   { outputEntryLabel :: DmnCommon
@@ -408,54 +569,92 @@ data OutputEntry = OutputEntry
 
 makePrisms ''OutputEntry
 
+-- | @tLiteralExpression@ in the @<outputEntry>@ position.
 instance XmlPickler OutputEntry where
   xpickle =
     xpDMNElem "outputEntry" _OutputEntry
-      -- . xpFilterAttr (hasName "id" <+> hasName "name")
-      -- . xpFilterCont none -- TODO
-      $ xpickle
+      . xpIgnoredAttrs ["label", "typeRef", "expressionLanguage"]
+      $ xpPair xpickle (xpSeq' xpDmnAnnotations xpickle)
+
+-- | @tRuleAnnotation@ (XSD line 352): the @<annotationEntry>@ that hangs off a
+-- @<rule>@. DMN 1.3's own spelling of a row comment, so 'DMN.XML.XmlToDmnmd'
+-- carries it straight into 'DMN.Types.row_comments'. @<text>@ is @minOccurs=0@.
+newtype AnnotationEntry = AnnotationEntry (Maybe TextElement)
+  deriving (Show, Eq)
+
+makePrisms ''AnnotationEntry
+
+instance XmlPickler AnnotationEntry where
+  xpickle = xpDMNElem "annotationEntry" _AnnotationEntry $ xpOption xpickle
+
+-- | The text of an @<annotationEntry>@, or @""@ if it had no @<text>@ child.
+annotationEntryText :: AnnotationEntry -> String
+annotationEntryText (AnnotationEntry mt) = maybe "" innerText mt
+
+-- | @tRuleAnnotationClause@ (XSD line 338): the column header for one
+-- @<annotationEntry>@ position. Carries a @name@ and nothing else.
+newtype AnnotationClause = AnnotationClause (Maybe String)
+  deriving (Show, Eq)
+
+makePrisms ''AnnotationClause
+
+instance XmlPickler AnnotationClause where
+  xpickle =
+    xpDMNElem "annotation" _AnnotationClause . xpFilterCont none $
+      xpOption (xpAttr "name" xpText)
+
+annotationClauseName :: AnnotationClause -> String
+annotationClauseName (AnnotationClause n) = maybe "" id n
 
 data Rule = Rule
   { ruleLabel :: DmnCommon
   , ruleDescription :: Maybe Description
   , ruleInputEntry :: [InputEntry]
   , ruleOutputEntry :: [OutputEntry] -- TODO: Should be NonEmpty
+  , ruleAnnotations :: [AnnotationEntry]
   }
   deriving (Show, Eq)
 
 makePrisms ''Rule
 
+-- | @tDecisionRule@: @description?@, @extensionElements?@, @inputEntry*@,
+-- @outputEntry+@, @annotationEntry*@. Both @description@ and @annotationEntry@
+-- are kept; they become row comments.
 instance XmlPickler Rule where
   xpickle =
     xpDMNElem "rule" _Rule
-      -- . xpFilterCont none -- TODO
-      -- . xpFilterCont (none `when` hasName "hitPolicy")
-      -- . xpFilterCont (hasName "description" <+> hasName "inputEntry")
-      -- . xpFilterCont (none `when` hasName "outputEntry")
-      $ xpickle
+      . xpIgnoredAttr "label"
+      $ xp5Tuple
+          xpickle
+          (xpOption xpickle)
+          (xpSeq' xpExtensionElements xpickle)
+          xpickle
+          xpickle
 
 data DecisionTable = DecisionTable
   { dtLabel :: DmnCommon,
     dtHitPolicy :: DT.HitPolicy,
     dtInput :: [TableInput],
     dtOutput :: [TableOutput], -- TODO: Should be NonEmpty
+    dtAnnotations :: [AnnotationClause],
     dtRules :: [Rule]
   }
   deriving (Show, Eq)
 
 makePrisms ''DecisionTable
 
+-- | @tDecisionTable@: @description?@, @extensionElements?@, @input*@,
+-- @output+@, @annotation*@, @rule*@.
 instance XmlPickler DecisionTable where
   xpickle =
     xpDMNElem "decisionTable" _DecisionTable
-      -- . xpFilterAttr (hasName "id" <+> hasName "name") -- TODO
-      -- . xpFilterAttr (none `when` hasName "hitPolicy")
-      -- . xpFilterCont none -- TODO
-      $ xp5Tuple
+      . xpIgnoredAttrs ["label", "typeRef", "preferredOrientation", "outputLabel"]
+      $ xp6Tuple
         xpickle
         xpHitPolicy
-        xpickle
+        (xpSeq' xpDmnAnnotations xpickle)
         (xpList1 xpickle)
+        xpickle
         xpickle
 
 data Expression = ExprDTable DecisionTable | ExprLiteral LiteralExpression
@@ -482,25 +681,74 @@ data Decision = Decision
 
 makePrisms ''Decision
 
+-- | @tDecision@: @description?@, @extensionElements?@, @question?@,
+-- @allowedAnswers?@, @variable?@, @informationRequirement*@,
+-- @knowledgeRequirement*@, @authorityRequirement*@, then a run of
+-- @tDMNElementReference@ children, then the decision logic (@expression?@).
+--
+-- The previous version used name-based content filters for @variable@ and
+-- @authorityRequirement@, which accepted them anywhere among the children.
+-- These are positional: an element out of schema order is still an error.
 instance XmlPickler Decision where
   xpickle =
     xpDMNElem "decision" _Decision
-      -- . xpFilterAttr (hasName "id" <+> hasName "name")
-      -- . xpFilterCont none -- TODO
-      . ignoreContent ["authorityRequirement"] -- We don't care about "Authority" which express where rules come from
-      . ignoreContent ["variable"] -- I don't know what this is
-      $ xpickle
+      . xpIgnoredAttr "label"
+      $ xpTriple
+          xpickle
+          (xpSeq' decisionPrelude xpickle)
+          (xpSeq' decisionInterlude xpickle)
+    where
+      decisionPrelude =
+        xpWrap (const (), const ((), ((), ((), ())))) $
+          xpPair
+            xpDmnAnnotations
+            (xpPair
+              (xpIgnoredElemOpt "question")
+              (xpPair (xpIgnoredElemOpt "allowedAnswers") (xpIgnoredElemOpt "variable")))
+      decisionInterlude =
+        xpIgnoredElemsOf
+          [ "knowledgeRequirement", "authorityRequirement"
+          , "supportedObjective", "impactedPerformanceIndicator"
+          , "decisionMaker", "decisionOwner", "usingProcess", "usingTask"
+          ]
 
+-- | @tInformationItem@ in the @<variable>@ position. Parsed but not modelled
+-- beyond its existence — see 'InputData'.
+data InformationItem = InformationItem
+  { iiLabel :: DmnNamed
+  , iiTypeRef :: Maybe TypeRef
+  }
+  deriving (Show, Eq)
+
+makePrisms ''InformationItem
+
+-- | @tInputData@: @description?@, @extensionElements?@, @variable?@.
+--
+-- The @<variable>@ is how DMN names the value an @<inputData>@ node carries, so
+-- real files have one almost always; before this change /any/ child element at
+-- all made the whole document fail to unpickle.
 data InputData = InputData
   { inpLabel :: DmnNamed
+  , inpVariable :: Maybe InformationItem
   }
   deriving (Show, Eq)
 
 makePrisms ''InputData
 
-instance XmlPickler InputData where
-  xpickle = xpDMNElem "inputData" _InputData $ xpickle
+xpVariable :: PU InformationItem
+xpVariable =
+  xpDMNElem "variable" _InformationItem
+    . xpIgnoredAttr "label"
+    $ xpPair xpickle (xpSeq' xpDmnAnnotations (xpOption xpickle))
 
+instance XmlPickler InputData where
+  xpickle =
+    xpDMNElem "inputData" _InputData
+      . xpIgnoredAttr "label"
+      $ xpPair xpickle (xpSeq' xpDmnAnnotations (xpOption xpVariable))
+
+-- | @tKnowledgeSource@: provenance metadata, not decision logic. Consumed
+-- wholesale.
 data KnowledgeSource = KnowledgeSource
   { knsLabel :: DmnNamed
   }
@@ -511,8 +759,8 @@ makePrisms ''KnowledgeSource
 instance XmlPickler KnowledgeSource where
   xpickle =
     xpDMNElem "knowledgeSource" _KnowledgeSource
-      -- . xpFilterAttr (hasName "id" <+> hasName "name")
-      . xpFilterCont none -- TODO
+      . xpIgnoredAttrs ["label", "locationURI"]
+      . xpFilterCont none
       $ xpickle
 
 data Namespace = Namespace { namespace :: String }
@@ -571,17 +819,43 @@ ex3 =
       defDMNDI = Just DMNDI
     }
 
+-- | @tDefinitions@: @description?@, @extensionElements?@, @import*@,
+-- @itemDefinition*@, @drgElement*@, @artifact*@, @elementCollection*@,
+-- @businessContextElement*@, @dmndi:DMNDI?@.
+--
+-- @defInputData@ / @defsDescisions@ / @defDrgElems@ are a greedy split of the
+-- one @drgElement*@ run: leading @<inputData>@, then leading @<decision>@, then
+-- whatever mixture follows. 'DMN.XML.XmlToDmnmd.convertIt' therefore has to look
+-- for decisions in both of the last two.
+--
+-- Namespace declarations are no longer demanded here (see 'stripIgnorableAttrs'):
+-- requiring a fixed set of them rejected minimal DMN 1.3 files that declare only
+-- the model namespace, and also rejected files carrying one extra declaration.
+-- The document is still pinned to DMN 1.3 by 'xpDMNElem', which matches
+-- @definitions@ only in the 1.3 model namespace.
 dmnPickler :: PU XDMN
 dmnPickler =
   xpDMNElem "definitions" _Definitions
-    . withNS
-    -- . xpFilterAttr (getAttrValue _ _)
-    -- . xpSeq' (xpAttr "namespace" xpUnit)  -- Ignore the namespace (I want to do the above though)
-    -- . xpAddFixedAttr "namespace" xmlns_camunda -- Ignore the namespace (I want to do the above though, and make it optional)
-    . ignoreContent ["dmndi"] -- We're not interested in diagrams
-    . ignoreContent ["variable"] -- I don't know what this is
-    . xpFilterAttr (none `when` (hasName "exporter" <+> hasName "exporterVersion") ) -- Used by Camunda Modeler
-    $ xpickle
+    . xpIgnoredAttrs ["label", "expressionLanguage", "typeLanguage", "exporter", "exporterVersion"]
+    $ xp6Tuple
+        xpickle                                  -- id / name attributes
+        xpickle                                  -- namespace attribute
+        (xpSeq' definitionsPrelude xpickle)      -- [InputData]
+        xpickle                                  -- [Decision]
+        xpickle                                  -- [DrgElems]
+        (xpSeq' definitionsEpilogue xpickle)     -- Maybe DMNDI
+  where
+    definitionsPrelude =
+      xpWrap (const (), const ((), ((), ()))) $
+        xpPair
+          xpDmnAnnotations
+          (xpPair (xpIgnoredElems "import") (xpIgnoredElems "itemDefinition"))
+    definitionsEpilogue =
+      xpIgnoredElemsOf
+        [ "association", "textAnnotation"          -- artifact
+        , "elementCollection"
+        , "performanceIndicator", "organizationUnit" -- businessContextElement
+        ]
 
 --     <variable id="InformationItem_1mjp1b5" name="safe price" typeRef="double" />
 
@@ -605,8 +879,77 @@ instance XmlPickler Definitions where
 pickleConfig :: [SysConfig]
 pickleConfig = [withValidate no, withCheckNamespaces yes, withRemoveWS yes, withIndent yes]
 
+-- | Read a DMN 1.3 file, reporting *why* it could not be read.
+--
+-- 'Text.XML.HXT.Arrow.Pickle.xunpickleDocument' swallows unpickling failures:
+-- it prints @fatal error: document unpickling failed@ and yields an empty list,
+-- which is indistinguishable from a valid file containing nothing. Callers then
+-- reported success. Here a failure is a 'Left' that the caller has to deal with.
+parseDMNEither :: FilePath -> IO (Either String [XDMN])
+parseDMNEither filename = do
+  roots <- runX $ readDocument pickleConfig filename
+                    >>> getChildren >>> isElem
+                    >>> stripIgnorableAttrs
+  pure $ case roots of
+    [] ->
+      Left $ filename ++ ": no XML root element found"
+          ++ " (the file is missing, empty, or not well-formed XML)."
+    (root : _) -> do
+      checkDmnRoot filename root
+      case unpickleDoc' dmnPickler root of
+        Left msg -> Left $ filename ++ ": " ++ readerRefusal root ++ "\n" ++ msg
+        Right v  -> Right [v]
+
+-- | Say what actually went wrong.
+--
+-- The document has already been confirmed to be a DMN 1.3 @<definitions>@ by
+-- 'checkDmnRoot', so blaming the version — as this message used to, for every
+-- unpickling failure whatsoever — was simply false. The commonest real cause is
+-- a DRG element that DMN 1.3 permits and dmnmd does not model
+-- (@<businessKnowledgeModel>@, @<decisionService>@ …); name those when they are
+-- present, and otherwise admit that we only have the unpickler's complaint.
+readerRefusal :: XmlTree -> String
+readerRefusal root
+  | not (null unmodelled) =
+      "this is valid DMN 1.3, but it contains "
+        ++ intercalate ", " (map (\n -> "<" ++ n ++ ">") unmodelled)
+        ++ ", which dmnmd does not model. Only <decision>, <inputData> and"
+        ++ " <knowledgeSource> are read."
+  | otherwise = "dmnmd could not read this DMN 1.3 document."
+  where
+    childNames = runLA (getChildren >>> isElem >>> getQName >>> arr localPart) root
+    unmodelled = nub (filter (`elem` unmodelledDrgElements) childNames)
+
+-- | Children of @<definitions>@ that the DMN 1.3 XSD allows but this reader has
+-- no representation for. Listing them is what lets 'readerRefusal' tell the
+-- truth instead of guessing at the version.
+unmodelledDrgElements :: [String]
+unmodelledDrgElements =
+  [ "businessKnowledgeModel", "decisionService" ]
+
+-- | Reject non-DMN-1.3 documents up front, naming what we actually found.
+-- Without this, a DMN 1.1 or 1.2 file (correctly refused) failed with
+-- @xpElem: got element name \"...\"@ deep inside the pickler.
+checkDmnRoot :: FilePath -> XmlTree -> Either String ()
+checkDmnRoot filename root =
+  case listToMaybe (runLA getQName root) of
+    Nothing -> Left $ filename ++ ": XML root element has no name."
+    Just qn
+      | localPart qn /= "definitions" ->
+          Left $ filename ++ ": expected a <definitions> root element, but found <"
+              ++ qualifiedName qn ++ ">."
+      | namespaceUri qn == xmlns_dmn -> Right ()
+      | otherwise ->
+          Left $ filename ++ ": <definitions> is in namespace "
+              ++ show (namespaceUri qn) ++ versionNote
+              ++ ".\ndmnmd reads DMN 1.3 only, i.e. " ++ show xmlns_dmn ++ "."
+      where
+        versionNote = maybe "" (\v -> " (" ++ v ++ ")") (dmnVersionOfNamespace (namespaceUri qn))
+
+-- | Backwards-compatible wrapper: throws in 'IO' on a bad document rather than
+-- returning an empty list.
 parseDMN :: FilePath -> IO [XDMN]
-parseDMN filename = runX $ xunpickleDocument dmnPickler pickleConfig filename
+parseDMN filename = either fail pure =<< parseDMNEither filename
 
 -- runX $ constA undefined >>> xpickleDTD @_ @() (xpickle :: PU Decision)
 -- runX $ constA undefined >>> xpickleDTD @_ @() (xpickle :: PU Decision) >>> writeDocumentToString []

--- a/languages/haskell/src/DMN/XML/XmlToDmnmd.hs
+++ b/languages/haskell/src/DMN/XML/XmlToDmnmd.hs
@@ -1,12 +1,35 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wincomplete-patterns #-}
+
+-- | Turn the DMN XML syntax tree from "DMN.XML.ParseDMN" into dmnmd's own
+-- 'DMN.Types.DecisionTable'.
+--
+-- The rule this module is written to:
+--
+-- > Anything we parse but do not yet honour must produce a loud, located
+-- > diagnostic. Never silently discard.
+--
+-- Concretely that means three things:
+--
+-- * Conversion returns 'Diagnostic's as values rather than calling @error@, so
+--   one bad column no longer takes the whole document with it, and the caller
+--   can decide the exit status.
+-- * A construct we cannot represent faithfully makes us refuse /that table/.
+--   Emitting a table that quietly never matches is worse than emitting none.
+-- * A construct we parse but drop gets a warning naming the table, the column
+--   and what was lost.
 module DMN.XML.XmlToDmnmd where
 
 import DMN.XML.ParseDMN as X
 import qualified DMN.Types as T
-import Data.Maybe (maybeToList)
-import qualified Data.List as L
-import DMN.DecisionTable (mkFs)
+import Data.Char (toLower, digitToInt)
+import Data.List (transpose, intercalate)
+import DMN.DecisionTable (inferTypes, mkFs, mkFsEither)
+import DMN.ParsingUtils (Parser, parseOnly)
+import qualified Data.Text as Text
+import qualified Text.Megaparsec as M
+import Text.Megaparsec.Char (char, space, hexDigitChar)
 
 -- $> :t runEx1
 
@@ -14,120 +37,507 @@ import DMN.DecisionTable (mkFs)
 
 -- $> convertIt =<< dmnThings
 
-convertAll :: [XDMN] -> [T.DecisionTable]
-convertAll x = x >>= convertIt
+-- * Diagnostics
 
-convertIt :: X.XDMN -> [T.DecisionTable]
-convertIt d = do
-    desicions <- X.defsDescisions d
-    convdec desicions
+data Severity = Warning | Error
+  deriving (Show, Eq)
 
-convdec :: X.Decision -> [T.DecisionTable]
-convdec dec = do
-    let decisionName = dmnnName $ decLabel dec
-    ExprDTable tabl <- maybeToList $ X.decDTable dec -- TODO: Partial!
-    pure $ convTable decisionName tabl
+-- | A complaint about the document, attributed to the table (and where
+-- possible the column and rule) it came from.
+data Diagnostic = Diagnostic
+  { diagSeverity :: Severity
+  , diagMessage :: String
+  }
+  deriving (Show, Eq)
 
-convTable :: String -> X.DecisionTable -> T.DecisionTable
--- convTable = undefined
-convTable name (X.DecisionTable
-  { X.dtLabel,
-    X.dtHitPolicy ,
-    X.dtInput ,
-    X.dtOutput ,
-    X.dtRules
-  }) = T.DTable 
-    { T.tableName = name
-    , T.hitpolicy = dtHitPolicy
-    , T.header    = inputHeaders ++ outputHeaders
-    , T.allrows   = zipWith (convRule inputTypes outputTypes) [1..] dtRules
+warnAt :: String -> Diagnostic
+warnAt = Diagnostic Warning
+
+errorAt :: String -> Diagnostic
+errorAt = Diagnostic Error
+
+isError :: Diagnostic -> Bool
+isError = (== Error) . diagSeverity
+
+anyErrors :: [Diagnostic] -> Bool
+anyErrors = any isError
+
+renderDiagnostic :: Diagnostic -> String
+renderDiagnostic (Diagnostic Warning m) = "warning: " ++ m
+renderDiagnostic (Diagnostic Error m) = "error: " ++ m
+
+-- * Conversion
+
+-- | Convert parsed DMN into dmnmd decision tables, together with any
+-- diagnostics produced along the way.
+convertAll :: [XDMN] -> ([Diagnostic], [T.DecisionTable])
+convertAll = mconcat . map convertIt
+
+convertIt :: X.XDMN -> ([Diagnostic], [T.DecisionTable])
+convertIt d = mconcat (map convdec (allDecisions d))
+
+-- | Every @<decision>@ in the file. 'X.defsDescisions' only holds the leading
+-- run of them: a file that interleaves @<inputData>@ with @<decision>@ puts the
+-- rest in 'X.defDrgElems', and those used to be dropped on the floor.
+allDecisions :: X.XDMN -> [X.Decision]
+allDecisions d = X.defsDescisions d ++ [dec | X.DrgDec dec <- X.defDrgElems d]
+
+convdec :: X.Decision -> ([Diagnostic], [T.DecisionTable])
+convdec dec = case X.decDTable dec of
+    Just (X.ExprDTable tabl) -> convTable decisionName tabl
+    Just (X.ExprLiteral _)   ->
+      ([ warnAt $ "decision " ++ show decisionName
+          ++ ": its decision logic is a <literalExpression>, not a <decisionTable>; skipped." ], [])
+    Nothing ->
+      ([ warnAt $ "decision " ++ show decisionName ++ ": no decision logic; skipped." ], [])
+  where
+    decisionName = dmnnName $ decLabel dec
+
+-- | One column of the table, before its cells have been looked at.
+data Col = Col
+  { colKind :: T.DTCH_Label
+  , colName :: String
+  , colDeclared :: Maybe T.DMNType
+    -- ^ the @typeRef@, if there was one and we understood it. 'Nothing' means
+    -- "no usable declaration", which is the only case in which we infer.
+  , colValuesText :: Maybe String
+    -- ^ the FEEL text of @<inputValues>@ / @<outputValues>@, the column's
+    -- declared domain. Becomes 'T.enums'.
+  }
+
+-- | Convert one @<decisionTable>@.
+--
+-- Either we emit a table we believe in, or we emit none and say why. There is
+-- no middle setting: a table whose guards can never fire, or whose rules have
+-- been silently widened by a dropped entry, is not a lesser version of the
+-- right answer — it is a wrong answer that exits 0.
+convTable :: String -> X.DecisionTable -> ([Diagnostic], [T.DecisionTable])
+convTable name X.DecisionTable
+  { X.dtHitPolicy
+  , X.dtInput
+  , X.dtOutput
+  , X.dtAnnotations
+  , X.dtRules
+  }
+  | anyErrors structural = (structural, [])
+  | anyErrors cellDiags  = (structural ++ cellDiags, [])
+  | otherwise            = (structural ++ cellDiags, [table])
+  where
+    inTable :: String -> String
+    inTable msg = "table " ++ show name ++ ": " ++ msg
+
+    -- ---- columns -------------------------------------------------------
+    (inColDiags,  inCols)  = unzip' (zipWith (convInputCol  inTable) [1 ..] dtInput)
+    (outColDiags, outCols) = unzip' (zipWith (convOutputCol inTable) [1 ..] dtOutput)
+
+    nIn = length dtInput
+    nOut = length dtOutput
+    nRows = length dtRules
+
+    -- ---- structural checks ---------------------------------------------
+    -- A rule with more entries than there are columns had the surplus dropped
+    -- by zipWith, which broadens what the rule matches. A rule with fewer had
+    -- a column invented for it. Both are XSD violations, not degradations.
+    arityDiags = concat (zipWith checkArity [1 :: Int ..] dtRules)
+
+    checkArity ix r =
+      concat
+        [ arity "inputEntry" nIn (length (ruleInputEntry r))
+        , arity "outputEntry" nOut (length (ruleOutputEntry r))
+        , annotationArity (length (ruleAnnotations r))
+        ]
+      where
+        rid = ruleIdent ix r
+        arity what expected actual
+          | expected == actual = []
+          | otherwise =
+              [ errorAt . inTable $
+                  rid ++ " has " ++ show actual ++ " <" ++ what ++ "> element"
+                      ++ plural actual ++ " but the table declares " ++ show expected
+                      ++ " column" ++ plural expected ++ "."
+                      ++ " DMN requires one entry per column." ]
+        annotationArity actual
+          | actual == length dtAnnotations = []
+          | otherwise =
+              [ warnAt . inTable $
+                  rid ++ " has " ++ show actual ++ " <annotationEntry> element"
+                      ++ plural actual ++ " but the table declares "
+                      ++ show (length dtAnnotations) ++ " <annotation> column"
+                      ++ plural (length dtAnnotations)
+                      ++ "; the extra text is still carried into the row comments." ]
+
+    annotationDiags
+      | null dtAnnotations = []
+      | otherwise =
+          [ warnAt . inTable $
+              "the <annotation> column names ("
+                ++ intercalate ", " (map (show . annotationClauseName) dtAnnotations)
+                ++ ") are dropped. Each rule's <annotationEntry> text is kept, as a row"
+                ++ " comment, but dmnmd has no place to record which annotation column"
+                ++ " it came from." ]
+
+    structural = inColDiags ++ outColDiags ++ arityDiags ++ annotationDiags
+
+    -- ---- cells ----------------------------------------------------------
+    -- Column-major: the type of a column is a property of the whole column, so
+    -- the cells cannot be built until every cell text in it has been seen.
+    inTexts  = columnTexts nIn  [map entryText (ruleInputEntry r)  | r <- dtRules]
+    outTexts = columnTexts nOut [map entryText (ruleOutputEntry r) | r <- dtRules]
+
+    ruleIdents = zipWith ruleIdent [1 ..] dtRules
+
+    inResolved  = zipWith (resolveColumn inTable ruleIdents) inCols  inTexts
+    outResolved = zipWith (resolveColumn inTable ruleIdents) outCols outTexts
+
+    cellDiags = concatMap rcDiags inResolved ++ concatMap rcDiags outResolved
+
+    -- ---- assembly --------------------------------------------------------
+    header = map rcHeader inResolved ++ map rcHeader outResolved
+
+    inByRow  = byRow nRows nIn  (map rcCells inResolved)
+    outByRow = byRow nRows nOut (map rcCells outResolved)
+
+    rows =
+      [ T.DTrow
+          { T.row_number = Just i
+          , T.row_inputs = ins
+          , T.row_outputs = outs
+          , T.row_comments =
+              fmap description (ruleDescription r)
+                : map (Just . annotationEntryText) (ruleAnnotations r)
+          }
+      | (i, r, ins, outs) <- zip4 [1 ..] dtRules inByRow outByRow
+      ]
+
+    table = T.DTable
+      { T.tableName = name
+      , T.hitpolicy = dtHitPolicy
+      , T.header = header
+      , T.allrows = rows
+      }
+
+-- | @<input>@ → column descriptor. The variable name is the FEEL text of the
+-- @<inputExpression>@; the display label and a positional name are fallbacks,
+-- rather than the old literal @"I don't know?"@.
+convInputCol :: (String -> String) -> Int -> TableInput -> (Diagnostics, Col)
+convInputCol inTable ix TableInput { tinpLabel, tinpExpr = InputExpression inpexpr, tinpValues } =
+    ( diags
+    , Col { colKind = T.DTCH_In
+          , colName = nm
+          , colDeclared = ty
+          , colValuesText = fmap (innerText . utText . unInputValues) tinpValues
+          }
+    )
+  where
+    nm = firstNonEmpty
+      [ maybe "" innerText (tleContent inpexpr)
+      , maybe "" columnLabel tinpLabel
+      , "input" ++ show ix
+      ]
+    (diags, ty) = resolveType (inTable . (("input column " ++ show nm ++ ": ") ++))
+                              (exprTypeRef (tleExpr inpexpr))
+
+-- | @<output>@ → column descriptor. DMN 1.3 makes @label@, @name@ and
+-- @typeRef@ all optional on @<output>@, so none can be assumed present.
+convOutputCol :: (String -> String) -> Int -> TableOutput -> (Diagnostics, Col)
+convOutputCol inTable ix TableOutput { toutName, toutLabel, toutTypeRef, toutValues, toutDefault } =
+    ( diags ++ defaultDiags
+    , Col { colKind = T.DTCH_Out
+          , colName = nm
+          , colDeclared = ty
+          , colValuesText = fmap (innerText . utText . unOutputValues) toutValues
+          }
+    )
+  where
+    nm = firstNonEmpty
+      [ maybe "" columnLabel toutLabel
+      , maybe "" id (dmnLabel toutName)
+      , "output" ++ show ix
+      ]
+    (diags, ty) = resolveType (inTable . (("output column " ++ show nm ++ ": ") ++)) toutTypeRef
+
+    -- <defaultOutputEntry> is the value the table takes when no rule matches.
+    -- dmnmd's DecisionTable has no slot for it — the L4 backend's own
+    -- L4Opts.defaultResult is set by the CLI, not by the table — so it is
+    -- parsed, checked, and then genuinely lost. Say so, with the value, rather
+    -- than emitting an OTHERWISE that quietly disagrees with the source file.
+    defaultDiags = case toutDefault of
+      Nothing -> []
+      Just d ->
+        [ warnAt . inTable $
+            "output column " ++ show nm ++ " declares <defaultOutputEntry> "
+              ++ show (defaultOutputText d)
+              ++ ", which dmnmd does not carry into its decision table."
+              ++ " The generated code will fall back to its own default instead."
+              ++ " Pass the value to the backend explicitly if it matters." ]
+
+defaultOutputText :: DefaultOutputEntry -> String
+defaultOutputText (DefaultOutputEntry tle) = maybe "" innerText (tleContent tle)
+
+unInputValues :: InputValues -> UnaryTestsBody
+unInputValues (InputValues b) = b
+
+unOutputValues :: OutputValues -> UnaryTestsBody
+unOutputValues (OutputValues b) = b
+
+type Diagnostics = [Diagnostic]
+
+-- | A column after its cells have been read: header, cells (row-major within
+-- the column) and whatever we had to complain about.
+data ResolvedCol = ResolvedCol
+  { rcHeader :: T.ColHeader
+  , rcCells :: [[T.FEELexp]]
+  , rcDiags :: Diagnostics
+  }
+
+-- | Give a column its type and build its cells.
+--
+-- Type inference is applied to a column only when it has no usable @typeRef@.
+-- DMN carries the types explicitly, so guessing at a declared column — and
+-- worse, letting a guess override or truncate it, which is what running
+-- markdown's whole-table 'DMN.DecisionTable.mkDTable' pass over XML did — is
+-- never right.
+resolveColumn :: (String -> String) -> [String] -> Col -> [String] -> ResolvedCol
+resolveColumn inTable ruleIdents col texts = ResolvedCol
+    { rcHeader = T.DTCH
+        { T.label = colKind col
+        , T.varname = colName col
+        , T.vartype = ty
+        , T.enums = enums
+        }
+    , rcCells = map snd built
+    , rcDiags = concatMap fst built ++ enumDiags
     }
-    where
-        inputHeaders = map convInputHeader dtInput
-        outputHeaders = map convOutputHeader dtOutput
-        inputTypes = map T.vartype inputHeaders
-        outputTypes = map T.vartype outputHeaders
+  where
+    where_ = inTable . ((kindWord ++ " column " ++ show (colName col) ++ ": ") ++)
+    kindWord = case colKind col of
+      T.DTCH_In -> "input"
+      T.DTCH_Out -> "output"
+      T.DTCH_Comment -> "comment"
 
+    -- First pass: read every cell as an untyped string. This is exactly the
+    -- evidence inferType wants — in particular the FEEL quotes are still on
+    -- "2020", which is the only thing that distinguishes it from the number.
+    firstPass = map (mkFs Nothing) texts
 
--- data InOrOut = TIn X.TableInput | TOut X.TableOutput
+    ty = case colDeclared col of
+      Just t -> Just t
+      Nothing -> T.vartype (inferTypes (T.DTCH (colKind col) (colName col) Nothing Nothing) firstPass)
 
--- inAndOut :: [X.TableInput] -> [X.TableOutput] -> [InOrOut]
--- inAndOut ins outs = map TIn ins ++ map TOut outs
+    built =
+      [ mkCells (\m -> where_ (atRule rid ++ m)) ty t
+      | (rid, t) <- zip (ruleIdents ++ repeat "") texts
+      ]
+    atRule "" = ""
+    atRule rid = rid ++ ": "
 
--- convHeader :: [X.TableInput] -> [X.TableOutput] -> [T.ColHeader]
--- -- convHeader ins outs = error $ "convHeader:\nIns: " ++ show ins ++ "\nouts: " ++ show outs
--- convHeader ins outs = map convHeader' $ inAndOut ins outs
+    (enumDiags, enums) = case colValuesText col of
+      Nothing -> ([], Nothing)
+      Just vtext ->
+        let (ds, fs) = mkCells (\m -> where_ ("declared value list: " ++ m)) ty vtext
+        in (ds, Just fs)
 
-convInputHeader :: TableInput -> T.ColHeader
-convInputHeader (tin@TableInput { tinpName , tinpLabel , tinpExpr = InputExpression inpexpr }) 
-    -- = error $ show tin
-    = T.DTCH 
-        { T.label   = T.DTCH_In
-        , T.varname = maybe "I don't know?" id . fmap innerText $ tleContent inpexpr -- TODO: I think this is correct, but I'm not sure
-        , T.vartype = fmap convertType . exprTypeRef $ tleExpr inpexpr
-        , T.enums   = Nothing -- TODO: This is definitely wrong
-        }
-    -- = error "not implemented"
+-- | Build the FEEL expressions for one cell, given the column's settled type.
+--
+-- The XML-side quoting is handled here, where the type is known, and by
+-- parsing: a string column's cell is read as a FEEL string literal (or a
+-- comma-separated list of them), escapes and surrounding whitespace included.
+-- What it is emphatically not is a first-char\/last-char test — that reinstated
+-- the double-quoting bug for anything with a newline round it, turned the FEEL
+-- string @"2020"@ into the number 2020 and @"007"@ into 7, and corrupted any
+-- expression that merely happened to start and end with a quote.
+mkCells :: (String -> String) -> Maybe T.DMNType -> String -> (Diagnostics, [T.FEELexp])
+mkCells locate ty text
+  | isStringy = case parseOnly feelStringList (Text.pack text) of
+      Right ss -> ([], [T.FNullary (T.VS s) | s <- ss])
+      Left _
+        | '"' `elem` text ->
+            ( [ warnAt . locate $
+                  show text ++ " is not a FEEL string literal, nor a comma-separated list"
+                    ++ " of them. dmnmd keeps the text as written — quotes included — and"
+                    ++ " splits it on commas, which is wrong for anything more structured"
+                    ++ " than a literal." ]
+            , verbatim )
+        | otherwise -> ([], verbatim)
+  | otherwise = case mkFsEither ty text of
+      Right fs -> ([], fs)
+      Left msg -> ([errorAt (locate msg)], [])
+  where
+    isStringy = ty == Nothing || ty == Just T.DMN_String
+    -- total for Nothing and DMN_String: both just keep the text
+    verbatim = mkFs ty text
 
-convOutputHeader :: TableOutput -> T.ColHeader
-convOutputHeader ( tout@TableOutput { toutName , toutLabel , toutTypeRef })
-    = T.DTCH 
-        { T.label   = T.DTCH_Out
-        , T.varname = columnLabel $ toutLabel -- TODO: Is this what we want?
-        , T.vartype = Just $ convertType $ toutTypeRef
-        , T.enums   = Nothing
-        }
+-- * FEEL string literals
 
-convertType :: TypeRef -> T.DMNType
-convertType (TypeRef "string") = T.DMN_String
-convertType (TypeRef "boolean") = T.DMN_Boolean
-convertType (TypeRef "integer") = T.DMN_Number
-convertType (TypeRef tname) = error $ "Unknown type: " ++ show tname
+-- | A FEEL string literal, or a comma-separated list of them — the shape a
+-- string column's @<inputEntry>@ \/ @<outputEntry>@ \/ @<outputValues>@ takes
+-- when it is a plain literal. Anything else fails, and the caller keeps the
+-- text verbatim rather than guessing.
+feelStringList :: Parser [String]
+feelStringList = space *> M.sepBy1 (feelString <* space) (char ',' *> space)
+
+feelString :: Parser String
+feelString = char '"' *> M.manyTill feelChar (char '"')
+
+feelChar :: Parser Char
+feelChar = (char '\\' *> feelEscape) M.<|> M.anySingle
+
+-- | Only the escapes FEEL defines. An unrecognised one fails the parse, which
+-- sends the cell down the verbatim path — better than inventing a meaning.
+feelEscape :: Parser Char
+feelEscape = M.choice
+  [ '\n' <$ char 'n'
+  , '\r' <$ char 'r'
+  , '\t' <$ char 't'
+  , '"'  <$ char '"'
+  , '\'' <$ char '\''
+  , '\\' <$ char '\\'
+  , char 'u' *> (toEnum . foldl (\acc d -> acc * 16 + digitToInt d) 0 <$> M.count 4 hexDigitChar)
+  ]
+
+-- * Types
+
+-- | Resolve a @typeRef@, attributing any complaint to the column it came from.
+resolveType :: (String -> String) -> Maybe TypeRef -> (Diagnostics, Maybe T.DMNType)
+resolveType _ Nothing = ([], Nothing)
+resolveType locate (Just tr) =
+  let (ds, ty) = convertType tr
+  in (map (\d -> d { diagMessage = locate (diagMessage d) }) ds, ty)
+
+-- | Map a DMN @typeRef@ onto a dmnmd column type.
+--
+-- DMN 1.3 §10.3.2.1 lists the built-in FEEL types as: number, string, boolean,
+-- date, time, date and time, days and time duration, years and months duration.
+--
+-- The temporal five are a hard error, not a degradation to string. dmnmd has no
+-- temporal type, and 'DMN.DecisionTable.mkF' on a string column stores the cell
+-- text verbatim — so an input entry of @< date("2020-01-01")@ becomes an
+-- equality test against the literal text @< date("2020-01-01")@ and the
+-- generated code can never match. A table we cannot represent must not be
+-- emitted in a form that silently never fires.
+--
+-- An unrecognised type (a user-defined @<itemDefinition>@, a vendor spelling)
+-- is different: we do not know that we cannot represent it, so it warns and
+-- leaves the column for inference, exactly as an absent @typeRef@ would.
+convertType :: TypeRef -> (Diagnostics, Maybe T.DMNType)
+convertType (TypeRef raw) = case canonical of
+    "number"   -> ok T.DMN_Number
+    "integer"  -> ok T.DMN_Number
+    "int"      -> ok T.DMN_Number
+    "long"     -> ok T.DMN_Number
+    "short"    -> ok T.DMN_Number
+    "double"   -> ok T.DMN_Number
+    "float"    -> ok T.DMN_Number
+    "decimal"  -> ok T.DMN_Number
+    "string"   -> ok T.DMN_String
+    "boolean"  -> ok T.DMN_Boolean
+    "bool"     -> ok T.DMN_Boolean
+    t | t `elem` temporalTypes ->
+          ( [ errorAt $
+                "typeRef " ++ show raw ++ " is a FEEL temporal type. dmnmd has no temporal"
+                  ++ " column type, and reading it as a string would turn every guard in"
+                  ++ " this column into a string comparison that can never match."
+                  ++ " Refusing to convert this table." ]
+          , Nothing )
+    -- An unrecognised typeRef is an ERROR, not a warning, for exactly the reason the
+    -- temporal branch above is: the document declares a domain we do not model, and
+    -- falling back to inference-from-cells can silently produce a String column whose
+    -- guards become literal string comparisons that never match. That is the
+    -- never-matching-guard defect wearing a different hat — refusing beats guessing.
+    -- Widening support is a matter of adding the type above, which the message says.
+    _ ->
+      ( [ errorAt $
+            "unknown typeRef " ++ show raw ++ ". dmnmd does not model this type, and"
+              ++ " inferring one from the cells risks turning every guard in this column"
+              ++ " into a string comparison that can never match."
+              ++ " Refusing to convert this table. Known types are: "
+              ++ unwords knownTypes ++ "." ]
+      , Nothing )
+  where
+    ok t = ([], Just t)
+    -- Strip any namespace prefix ("feel:string", "xsd:integer") and normalise
+    -- whitespace/case, so that "date and time" and "Date  And Time" agree.
+    canonical = unwords . words . map toLower . dropPrefix $ raw
+    dropPrefix s = case break (== ':') (reverse s) of
+      (rev, "") -> reverse rev
+      (rev, _)  -> reverse rev
+    temporalTypes =
+      [ "date", "time", "date and time", "datetime"
+      , "days and time duration", "daytimeduration"
+      , "years and months duration", "yearmonthduration", "yearsandmonthsduration"
+      ]
+    -- Every spelling the case above actually accepts, so the diagnostic does not
+    -- send the reader looking for a type that is already supported.
+    knownTypes =
+      [ "number", "integer", "int", "long", "short", "double", "float", "decimal"
+      , "string", "boolean", "bool"
+      ]
+
+-- * Small helpers
+
+entryTextOfInput :: InputEntry -> String
+entryTextOfInput (InputEntry { ieText = TextElement str }) = str
+
+entryTextOfOutput :: OutputEntry -> String
+entryTextOfOutput (OutputEntry { outputEntryText = TextElement str }) = str
+
+class HasEntryText a where
+  entryText :: a -> String
+
+instance HasEntryText InputEntry where
+  entryText = entryTextOfInput
+
+instance HasEntryText OutputEntry where
+  entryText = entryTextOfOutput
+
+-- | How a rule is named in a diagnostic: its @id@ if it has one, else its
+-- position.
+ruleIdent :: Int -> Rule -> String
+ruleIdent ix r = case dmnId (ruleLabel r) of
+  Just i -> "rule " ++ show i
+  Nothing -> "rule #" ++ show ix
+
+firstNonEmpty :: [String] -> String
+firstNonEmpty xs = case filter (not . null) xs of
+  (x : _) -> x
+  []      -> ""
+
+plural :: Int -> String
+plural 1 = ""
+plural _ = "s"
+
+unzip' :: [(Diagnostics, a)] -> (Diagnostics, [a])
+unzip' xs = (concatMap fst xs, map snd xs)
+
+-- | Row-major entry texts → column-major, with the column count fixed by the
+-- table's own declarations. Callers only reach this once arity has been
+-- checked, so the indexing is total.
+columnTexts :: Int -> [[String]] -> [[String]]
+columnTexts n rows = [[row !! j | row <- rows] | j <- [0 .. n - 1]]
+
+-- | Column-major cells → row-major. 'transpose' cannot do this alone: a table
+-- with rules but zero columns of a given kind transposes to @[]@ and would lose
+-- every row.
+byRow :: Int -> Int -> [[a]] -> [[a]]
+byRow nrows ncols cols
+  | ncols == 0 = replicate nrows []
+  | otherwise = transpose cols
+
+zip4 :: [a] -> [b] -> [c] -> [d] -> [(a, b, c, d)]
+zip4 (a : as) (b : bs) (c : cs) (d : ds) = (a, b, c, d) : zip4 as bs cs ds
+zip4 _ _ _ _ = []
+
+-- * Fixtures used from the REPL
 
 outThing :: TableOutput
 outThing =
   TableOutput
     { toutName = dmnLabeled "OuputClause_99999" "beverages",
-      toutLabel = ColumnLabel {columnLabel = "Beverages"},
-      toutTypeRef = TypeRef {typeRef = "string"}
+      toutLabel = Just ColumnLabel {columnLabel = "Beverages"},
+      toutTypeRef = Just TypeRef {typeRef = "string"},
+      toutValues = Nothing,
+      toutDefault = Nothing
     }
-
-
-{-
-thing :: TableInput
-thing =
-  TableInput
-    { tinpName = dmnWithId "InputClause_1acmlkd"
-    , tinpLabel = ColumnLabel { columnLabel = "Dish" }
-    , tinpExpr = InputExpression
-          { inputExprLabel = dmnWithId "LiteralExpression_0bqgrlg"
-          , inputExprTypeRef = TypeRef {typeRef = "string"}
-          , inputExprText = TextElement {innerText = "desiredDish"}
-          }
-    }
--}
-
-convRule :: [Maybe T.DMNType] -> [Maybe T.DMNType] -> Int -> Rule -> T.DTrow
-convRule intypes outtypes rowNumber ( Rule
-    { ruleLabel
-    , ruleDescription
-    , ruleInputEntry
-    , ruleOutputEntry
-    })
-    = T.DTrow
-        { T.row_number   = Just rowNumber
-        , T.row_inputs   = zipWith convInputEntry intypes ruleInputEntry
-        , T.row_outputs  = zipWith convOutputEntry outtypes ruleOutputEntry
-        , T.row_comments = pure $ fmap description ruleDescription -- TODO: This may be bogus
-        }
-
-convInputEntry :: Maybe T.DMNType -> InputEntry -> [T.FEELexp]
-convInputEntry intype (InputEntry { ieLabel , ieText = TextElement str }) 
-    = mkFs intype str
-
-convOutputEntry :: Maybe T.DMNType -> OutputEntry -> [T.FEELexp]
-convOutputEntry outtype (OutputEntry { outputEntryLabel , outputEntryText = TextElement str }) 
-    = mkFs outtype str
 
 oeExample :: OutputEntry
 oeExample =
@@ -142,10 +552,3 @@ ieExample =
     { ieLabel = dmnWithId "UnaryTests_03g3ci0"
     , ieText = TextElement { innerText = "\"Spareribs\"" }
     }
-
-
-{-
-
-    -- = error "not implemented"
-
---}

--- a/languages/haskell/test/DmnXmlSpec.hs
+++ b/languages/haskell/test/DmnXmlSpec.hs
@@ -6,7 +6,7 @@ module DmnXmlSpec where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import DMN.XML.ParseDMN
-import DMN.XML.XmlToDmnmd (convertAll)
+import DMN.XML.XmlToDmnmd (convertAll, Diagnostic (..), Severity (..))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Test.Hspec
@@ -41,7 +41,190 @@ xmlSpec = do
     pure ()
   describe "convertIt" $ do
     it "should convert the standard example properly" $
-      convertAll simulationDmn `shouldBe` convertedSimulation
+      snd (convertAll simulationDmn) `shouldBe` convertedSimulation
+  dmn13Spec
+
+-- * DMN 1.3
+--
+-- Every other XML fixture in test/ is DMN 1.1 or 1.2, so none of them ever
+-- reached the DMN 1.3 reader. These do: `baseline` is a known-good file and
+-- each of the others is `baseline` plus exactly one construct that used to make
+-- the whole document fail to unpickle. See test/dmn13/README.md.
+
+dmn13 :: FilePath -> FilePath
+dmn13 name = "test/dmn13/" ++ name ++ ".dmn"
+
+-- | Parse a DMN 1.3 fixture and convert it, failing the example with the
+-- reader's own diagnostic if it could not be read at all.
+readDmn13 :: FilePath -> IO ([Diagnostic], [DT.DecisionTable])
+readDmn13 name = do
+  parsed <- parseDMNEither (dmn13 name)
+  case parsed of
+    Left err   -> expectationFailure err >> pure ([], [])
+    Right defs -> pure (convertAll defs)
+
+-- | Does any diagnostic of the given severity mention this text?
+hasDiag :: Severity -> String -> [Diagnostic] -> Bool
+hasDiag sev needle =
+  any (\d -> diagSeverity d == sev && T.pack needle `T.isInfixOf` T.pack (diagMessage d))
+
+-- | The single decision table every accepting fixture is expected to yield.
+shouldBeAgeBand :: String -> [DT.DecisionTable] -> Expectation
+shouldBeAgeBand outName tables = case tables of
+  [t] -> do
+    tableName t `shouldBe` "Band"
+    hitpolicy t `shouldBe` HP_First
+    map varname (header t) `shouldBe` ["age", outName]
+    map vartype (header t) `shouldBe` [Just DMN_Number, Just DMN_String]
+    map row_outputs (allrows t)
+      `shouldBe` [ [[FNullary (VS "minor")]]
+                 , [[FNullary (VS "adult")]]
+                 , [[FNullary (VS "senior")]]
+                 ]
+  _ -> expectationFailure $ "expected exactly one decision table, got " ++ show (length tables)
+
+dmn13Spec :: Spec
+dmn13Spec = describe "DMN 1.3" $ do
+  describe "accepts" $ do
+    it "the known-good baseline" $ do
+      (warns, tables) <- readDmn13 "baseline"
+      warns `shouldBe` []
+      shouldBeAgeBand "Band" tables
+
+    it "<inputData> carrying <description> and <variable> (B1)" $ do
+      (warns, tables) <- readDmn13 "inputdata-variable"
+      warns `shouldBe` []
+      shouldBeAgeBand "Band" tables
+
+    it "<input>/<output> with no label= and <output> with no typeRef= (B2)" $ do
+      (warns, tables) <- readDmn13 "output-without-label"
+      warns `shouldBe` []
+      -- with no label the output column falls back to its name= attribute,
+      -- and with no typeRef its type is inferred from the cells
+      case tables of
+        [t] -> do
+          map varname (header t) `shouldBe` ["age", "band"]
+          map vartype (header t) `shouldBe` [Just DMN_Number, Just DMN_String]
+        _ -> expectationFailure "expected exactly one decision table"
+
+    it "<output> with a <defaultOutputEntry> (B3)" $ do
+      (warns, tables) <- readDmn13 "default-output-entry"
+      -- dmnmd's DecisionTable has nowhere to put a default output, so the value
+      -- IS lost. That must be said out loud, with the value in the message —
+      -- the alternative is an OTHERWISE arm that quietly contradicts the file.
+      warns `shouldSatisfy` hasDiag Warning "<defaultOutputEntry> \"\\\"unknown\\\"\""
+      warns `shouldNotSatisfy` any ((== Error) . diagSeverity)
+      shouldBeAgeBand "Band" tables
+
+    it "<outputValues> and <inputValues> (B3)" $ do
+      (warns, tables) <- readDmn13 "output-values"
+      warns `shouldBe` []
+      shouldBeAgeBand "Band" tables
+      -- the declared domain is not dropped: it lands in the column's enums,
+      -- which is exactly what dmnmd's own subheader rows populate.
+      case tables of
+        [t] -> map enums (header t)
+          `shouldBe` [ Just [FInRange 0 150]
+                     , Just [FNullary (VS "minor"), FNullary (VS "adult"), FNullary (VS "senior")]
+                     ]
+        _ -> expectationFailure "expected exactly one decision table"
+
+    it "a file declaring only the DMN model namespace (B5)" $ do
+      (warns, tables) <- readDmn13 "minimal-namespaces"
+      warns `shouldBe` []
+      shouldBeAgeBand "Band" tables
+
+    it "extra namespace declarations and foreign-namespace attributes (B5)" $ do
+      (warns, tables) <- readDmn13 "extra-namespace"
+      warns `shouldBe` []
+      shouldBeAgeBand "Band" tables
+
+    it "typeRef=\"number\", the FEEL numeric type (B4)" $ do
+      (warns, tables) <- readDmn13 "feel-number-type"
+      warns `shouldBe` []
+      case tables of
+        [t] -> do
+          map vartype (header t) `shouldBe` [Just DMN_Number, Just DMN_Number]
+          map row_outputs (allrows t)
+            `shouldBe` [ [[FNullary (VN 100)]], [[FNullary (VN 200)]], [[FNullary (VN 150)]] ]
+        _ -> expectationFailure "expected exactly one decision table"
+
+    it "an unrecognised typeRef, refusing the table rather than guessing (B4)" $ do
+      -- Deliberately an Error, not a Warning. An earlier pass inferred the column
+      -- type from the cells here, on the reasoning that an unknown typeRef might be
+      -- a user-defined <itemDefinition> that happens to be a string. Adversarial
+      -- review showed that is the SAME defect as the temporal case: inference can
+      -- settle on String, and `mkF (Just DMN_String)` stores a guard like "< 18"
+      -- verbatim, so every rule becomes an equality test against that literal and
+      -- the generated code can never match — silently, at exit 0. We do not know
+      -- the domain, so we refuse the table and name the type. Widening support is
+      -- a matter of adding the spelling to convertType.
+      (diags, tables) <- readDmn13 "unknown-type"
+      diags  `shouldSatisfy` hasDiag Error "unknown typeRef"
+      tables `shouldBe` []
+
+    it "carries <annotationEntry> text into the row comments" $ do
+      (_, tables) <- readDmn13 "annotations"
+      case tables of
+        [t] -> map row_comments (allrows t)
+          `shouldBe` [ [Just "children", Just "under the age of majority"]
+                     , [Nothing, Just "working age"]
+                     , [Nothing, Just "retired"]
+                     ]
+        _ -> expectationFailure "expected exactly one decision table"
+
+  describe "refuses the table" $ do
+    it "when a column's typeRef is a FEEL temporal type" $ do
+      -- degrading `date` to String would make `< date(\"2020-01-01\")` an
+      -- equality test against that literal text: a table that can never fire.
+      (diags, tables) <- readDmn13 "temporal-type"
+      diags `shouldSatisfy` hasDiag Error "temporal type"
+      tables `shouldBe` []
+
+    it "when a rule carries more <inputEntry> elements than there are columns" $ do
+      (diags, tables) <- readDmn13 "bad-rule-arity"
+      diags `shouldSatisfy` hasDiag Error "<inputEntry>"
+      diags `shouldSatisfy` hasDiag Error "Rule_2"
+      tables `shouldBe` []
+
+    it "when a rule carries no <outputEntry> at all" $ do
+      (diags, tables) <- readDmn13 "bad-rule-no-output"
+      diags `shouldSatisfy` hasDiag Error "<outputEntry>"
+      tables `shouldBe` []
+
+  describe "rejects" $ do
+    let shouldReject name expected = do
+          parsed <- parseDMNEither (dmn13 name)
+          case parsed of
+            Right _  -> expectationFailure $ dmn13 name ++ " should not have been accepted"
+            Left err -> T.pack err `shouldSatisfy` T.isInfixOf (T.pack expected)
+
+    it "a DMN 1.2 document, naming the version" $
+      shouldReject "not-dmn13" "DMN 1.2"
+    it "an element the schema does not allow there" $
+      shouldReject "bad-unknown-element" "unprocessed XML content"
+    it "an attribute in DMN's own vocabulary that the schema does not declare" $
+      shouldReject "bad-unknown-attribute" "unprocessed XML attribute"
+    it "children that are out of schema order" $
+      shouldReject "bad-misordered-child" "unprocessed XML content"
+
+    it "a legal <businessKnowledgeModel>, saying so rather than blaming the version" $ do
+      shouldReject "unsupported-drgelement" "<businessKnowledgeModel>"
+      -- the old message claimed "this is not DMN 1.3", which was simply untrue:
+      -- businessKnowledgeModel is a legal drgElement substitution in the
+      -- vendored XSD. We just do not model it.
+      parsed <- parseDMNEither (dmn13 "unsupported-drgelement")
+      case parsed of
+        Right _ -> expectationFailure "should not have been accepted"
+        Left e -> T.pack e `shouldNotSatisfy` T.isInfixOf "not DMN 1.3"
+
+  describe "FEEL string quoting" $
+    it "does not double-quote a FEEL string literal" $ do
+      -- <text>\"minor\"</text> must land in the IR as VS \"minor\", the same as
+      -- the markdown cell `minor`, so that both readers agree downstream.
+      (_, tables) <- readDmn13 "baseline"
+      concatMap (concatMap concat . map row_outputs . allrows) tables
+        `shouldBe` [FNullary (VS "minor"), FNullary (VS "adult"), FNullary (VS "senior")]
 
 convertedSimulation :: [DT.DecisionTable]
 convertedSimulation =
@@ -72,40 +255,40 @@ convertedSimulation =
           [ DTrow
               { row_number = Just 1,
                 row_inputs =
-                  [ [FNullary (VS "\"Spareribs\"")],
+                  [ [FNullary (VS "Spareribs")],
                     [FNullary (VB True)]
                   ],
-                row_outputs = [[FNullary (VS "\"Aecht Schlenkerla Rauchbier\"")]],
+                row_outputs = [[FNullary (VS "Aecht Schlenkerla Rauchbier")]],
                 row_comments = [Just "Tough Stuff"]
               },
             DTrow
               { row_number = Just 2,
                 row_inputs =
-                  [ [FNullary (VS "\"Stew\"")],
+                  [ [FNullary (VS "Stew")],
                     [FNullary (VB True)]
                   ],
-                row_outputs = [[FNullary (VS "\"Guiness\"")]],
+                row_outputs = [[FNullary (VS "Guiness")]],
                 row_comments = [Nothing]
               },
             DTrow
               { row_number = Just 3,
                 row_inputs =
-                  [ [FNullary (VS "\"Roastbeef\"")],
+                  [ [FNullary (VS "Roastbeef")],
                     [FNullary (VB True)]
                   ],
-                row_outputs = [[FNullary (VS "\"Bordeaux\"")]],
+                row_outputs = [[FNullary (VS "Bordeaux")]],
                 row_comments = [Nothing]
               },
             DTrow
               { row_number = Just 4,
                 row_inputs =
-                  [ [ FNullary (VS "\"Steak\""),
-                      FNullary (VS "\"Dry Aged Gourmet Steak\""),
-                      FNullary (VS "\"Light Salad and a nice Steak\"")
+                  [ [ FNullary (VS "Steak"),
+                      FNullary (VS "Dry Aged Gourmet Steak"),
+                      FNullary (VS "Light Salad and a nice Steak")
                     ],
                     [FNullary (VB True)]
                   ],
-                row_outputs = [[FNullary (VS "\"Pinot Noir\"")]],
+                row_outputs = [[FNullary (VS "Pinot Noir")]],
                 row_comments = [Nothing]
               },
             DTrow
@@ -114,7 +297,7 @@ convertedSimulation =
                   [ [FAnything],
                     [FNullary (VB True)]
                   ],
-                row_outputs = [[FNullary (VS "\"Apple Juice\"")]],
+                row_outputs = [[FNullary (VS "Apple Juice")]],
                 row_comments = [Nothing]
               },
             DTrow
@@ -123,7 +306,7 @@ convertedSimulation =
                   [ [FAnything],
                     [FNullary (VB False)]
                   ],
-                row_outputs = [[FNullary (VS "\"Water\"")]],
+                row_outputs = [[FNullary (VS "Water")]],
                 row_comments = [Nothing]
               }
           ]
@@ -154,6 +337,26 @@ convertedSimulation =
         allrows =
           [ DTrow
               { row_number = Just 1,
+                -- ============================ KNOWN DEFECT ============================
+                -- This is NOT the desired behaviour; it is the current behaviour,
+                -- frozen so that a change to it is noticed.
+                --
+                -- The source cell reads  not("Fall", "Winter", "Spring", "Summer") .
+                -- 'DMN.DecisionTable.mkFs' splits every cell on commas before
+                -- anything looks at what the cell means, so this single FEEL
+                -- negation is shredded into four fragments, two of which have
+                -- unbalanced quotes and parentheses. Nothing downstream can
+                -- reconstruct the negation.
+                --
+                -- Fixing that is the cell-language redesign, deliberately out of
+                -- scope here. What is in scope is that dmnmd now *says so*: the
+                -- reader emits a warning naming the table, column and rule and
+                -- stating that the text is kept verbatim and comma-split. The
+                -- quotes below are therefore intact — a previous attempt stripped
+                -- them from whichever fragments happened to begin and end with
+                -- one, which produced a mixture that looked half-parsed and was
+                -- neither the source text nor a parse of it.
+                -- ======================================================================
                 row_inputs =
                   [ [ FNullary (VS "not(\"Fall\""),
                       FNullary (VS "\"Winter\""),
@@ -162,64 +365,64 @@ convertedSimulation =
                     ],
                     [FSection Fgte (VN 0.0)]
                   ],
-                row_outputs = [[FNullary (VS "\"Instant Soup\"")]],
+                row_outputs = [[FNullary (VS "Instant Soup")]],
                 row_comments = [Just "Default value"]
               },
             DTrow
               { row_number = Just 2,
                 row_inputs =
-                  [ [FNullary (VS "\"Fall\"")],
+                  [ [FNullary (VS "Fall")],
                     [FSection Flte (VN 8.0)]
                   ],
-                row_outputs = [[FNullary (VS "\"Spareribs\"")]],
+                row_outputs = [[FNullary (VS "Spareribs")]],
                 row_comments = [Nothing]
               },
             DTrow
               { row_number = Just 3,
                 row_inputs =
-                  [ [FNullary (VS "\"Winter\"")],
+                  [ [FNullary (VS "Winter")],
                     [FSection Flte (VN 8.0)]
                   ],
-                row_outputs = [[FNullary (VS "\"Roastbeef\"")]],
+                row_outputs = [[FNullary (VS "Roastbeef")]],
                 row_comments = [Nothing]
               },
             DTrow
               { row_number = Just 4,
                 row_inputs =
-                  [ [FNullary (VS "\"Spring\"")],
+                  [ [FNullary (VS "Spring")],
                     [FSection Flte (VN 4.0)]
                   ],
-                row_outputs = [[FNullary (VS "\"Dry Aged Gourmet Steak\"")]],
+                row_outputs = [[FNullary (VS "Dry Aged Gourmet Steak")]],
                 row_comments = [Nothing]
               },
             DTrow
               { row_number = Just 5,
                 row_inputs =
-                  [ [FNullary (VS "\"Spring\"")],
+                  [ [FNullary (VS "Spring")],
                     [FInRange 5.0 8.0]
                   ],
-                row_outputs = [[FNullary (VS "\"Steak\"")]],
+                row_outputs = [[FNullary (VS "Steak")]],
                 row_comments = [Just "Save money"]
               },
             DTrow
               { row_number = Just 6,
                 row_inputs =
-                  [ [ FNullary (VS "\"Fall\""),
-                      FNullary (VS "\"Winter\""),
-                      FNullary (VS "\"Spring\"")
+                  [ [ FNullary (VS "Fall"),
+                      FNullary (VS "Winter"),
+                      FNullary (VS "Spring")
                     ],
                     [FSection Fgt (VN 8.0)]
                   ],
-                row_outputs = [[FNullary (VS "\"Stew\"")]],
+                row_outputs = [[FNullary (VS "Stew")]],
                 row_comments = [Just "Less effort"]
               },
             DTrow
               { row_number = Just 7,
                 row_inputs =
-                  [ [FNullary (VS "\"Summer\"")],
+                  [ [FNullary (VS "Summer")],
                     [FAnything]
                   ],
-                row_outputs = [[FNullary (VS "\"Light Salad and a nice Steak\"")]],
+                row_outputs = [[FNullary (VS "Light Salad and a nice Steak")]],
                 row_comments = [Just "Hey, why not?"]
               }
           ]
@@ -252,12 +455,13 @@ simulationDmn =
                   Just
                     ( ExprDTable
                         ( DecisionTable
-                            { dtLabel = dmnWithId "DecisionTable_07q05jb",
+                            { dtLabel = dmnWithId "DecisionTable_07q05jb", dtAnnotations = [],
                               dtHitPolicy = HP_Collect Collect_All,
                               dtInput =
                                 [ TableInput
                                     { tinpName = dmnWithId "InputClause_1acmlkd",
-                                      tinpLabel = ColumnLabel {columnLabel = "Dish"},
+                                      tinpLabel = Just ColumnLabel {columnLabel = "Dish"},
+                                      tinpValues = Nothing,
                                       tinpExpr =
                                         InputExpression
                                           ( TLiteralExpression
@@ -274,9 +478,10 @@ simulationDmn =
                                   TableInput
                                     { tinpName = dmnWithId "InputClause_0bo3uen",
                                       tinpLabel =
-                                        ColumnLabel
+                                        Just ColumnLabel
                                           { columnLabel = "Guests with children"
                                           },
+                                      tinpValues = Nothing,
                                       tinpExpr =
                                         InputExpression
                                           ( TLiteralExpression
@@ -294,13 +499,15 @@ simulationDmn =
                               dtOutput =
                                 [ TableOutput
                                     { toutName = dmnLabeled "OuputClause_99999" "beverages",
-                                      toutLabel = ColumnLabel {columnLabel = "Beverages"},
-                                      toutTypeRef = TypeRef {typeRef = "string"}
+                                      toutLabel = Just ColumnLabel {columnLabel = "Beverages"},
+                                      toutTypeRef = Just TypeRef {typeRef = "string"},
+                                      toutValues = Nothing,
+                                      toutDefault = Nothing
                                     }
                                 ],
                               dtRules =
                                 [ Rule
-                                    { ruleLabel = dmnWithId "row-506282952-7",
+                                    { ruleLabel = dmnWithId "row-506282952-7", ruleAnnotations = [],
                                       ruleDescription = Just (Description {description = "Tough Stuff"}),
                                       ruleInputEntry =
                                         [ InputEntry
@@ -320,7 +527,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-8",
+                                    { ruleLabel = dmnWithId "row-506282952-8", ruleAnnotations = [],
                                       ruleDescription = Nothing,
                                       ruleInputEntry =
                                         [ InputEntry
@@ -340,7 +547,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-9",
+                                    { ruleLabel = dmnWithId "row-506282952-9", ruleAnnotations = [],
                                       ruleDescription = Nothing,
                                       ruleInputEntry =
                                         [ InputEntry
@@ -360,7 +567,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-10",
+                                    { ruleLabel = dmnWithId "row-506282952-10", ruleAnnotations = [],
                                       ruleDescription = Nothing,
                                       ruleInputEntry =
                                         [ InputEntry
@@ -380,7 +587,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-11",
+                                    { ruleLabel = dmnWithId "row-506282952-11", ruleAnnotations = [],
                                       ruleDescription = Nothing,
                                       ruleInputEntry =
                                         [ InputEntry
@@ -400,7 +607,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-12",
+                                    { ruleLabel = dmnWithId "row-506282952-12", ruleAnnotations = [],
                                       ruleDescription = Nothing,
                                       ruleInputEntry =
                                         [ InputEntry
@@ -442,12 +649,13 @@ simulationDmn =
                   Just
                     ( ExprDTable
                         ( DecisionTable
-                            { dtLabel = dmnWithId "DecisionTable_040j91i",
+                            { dtLabel = dmnWithId "DecisionTable_040j91i", dtAnnotations = [],
                               dtHitPolicy = HP_Unique,
                               dtInput =
                                 [ TableInput
                                     { tinpName = dmnWithId "InputClause_0bbq1z8",
-                                      tinpLabel = ColumnLabel {columnLabel = "Season"},
+                                      tinpLabel = Just ColumnLabel {columnLabel = "Season"},
+                                      tinpValues = Nothing,
                                       tinpExpr =
                                         InputExpression
                                           ( TLiteralExpression
@@ -463,7 +671,8 @@ simulationDmn =
                                     },
                                   TableInput
                                     { tinpName = dmnWithId "InputClause_0pcbpc9",
-                                      tinpLabel = ColumnLabel {columnLabel = "How many guests"},
+                                      tinpLabel = Just ColumnLabel {columnLabel = "How many guests"},
+                                      tinpValues = Nothing,
                                       tinpExpr =
                                         InputExpression
                                           ( TLiteralExpression
@@ -481,13 +690,15 @@ simulationDmn =
                               dtOutput =
                                 [ TableOutput
                                     { toutName = dmnLabeled "OutputClause_0lfar1z" "desiredDish",
-                                      toutLabel = ColumnLabel {columnLabel = "Dish"},
-                                      toutTypeRef = TypeRef {typeRef = "string"}
+                                      toutLabel = Just ColumnLabel {columnLabel = "Dish"},
+                                      toutTypeRef = Just TypeRef {typeRef = "string"},
+                                      toutValues = Nothing,
+                                      toutDefault = Nothing
                                     }
                                 ],
                               dtRules =
                                 [ Rule
-                                    { ruleLabel = dmnWithId "row-884555325-1",
+                                    { ruleLabel = dmnWithId "row-884555325-1", ruleAnnotations = [],
                                       ruleDescription = Just (Description {description = "Default value"}),
                                       ruleInputEntry =
                                         [ InputEntry
@@ -507,7 +718,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-1",
+                                    { ruleLabel = dmnWithId "row-506282952-1", ruleAnnotations = [],
                                       ruleDescription = Nothing,
                                       ruleInputEntry =
                                         [ InputEntry
@@ -527,7 +738,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-2",
+                                    { ruleLabel = dmnWithId "row-506282952-2", ruleAnnotations = [],
                                       ruleDescription = Nothing,
                                       ruleInputEntry =
                                         [ InputEntry
@@ -547,7 +758,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-3",
+                                    { ruleLabel = dmnWithId "row-506282952-3", ruleAnnotations = [],
                                       ruleDescription = Nothing,
                                       ruleInputEntry =
                                         [ InputEntry
@@ -567,7 +778,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-4",
+                                    { ruleLabel = dmnWithId "row-506282952-4", ruleAnnotations = [],
                                       ruleDescription = Just (Description {description = "Save money"}),
                                       ruleInputEntry =
                                         [ InputEntry
@@ -587,7 +798,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-5",
+                                    { ruleLabel = dmnWithId "row-506282952-5", ruleAnnotations = [],
                                       ruleDescription = Just (Description {description = "Less effort"}),
                                       ruleInputEntry =
                                         [ InputEntry
@@ -607,7 +818,7 @@ simulationDmn =
                                         ]
                                     },
                                   Rule
-                                    { ruleLabel = dmnWithId "row-506282952-6",
+                                    { ruleLabel = dmnWithId "row-506282952-6", ruleAnnotations = [],
                                       ruleDescription = Just (Description {description = "Hey, why not?"}),
                                       ruleInputEntry =
                                         [ InputEntry
@@ -634,12 +845,12 @@ simulationDmn =
           ],
         defDrgElems =
           [ DrgInpData
-              (InputData {inpLabel = dmnNamed' "InputData_0rin549" "Season"}),
+              (InputData {inpLabel = dmnNamed' "InputData_0rin549" "Season", inpVariable = Nothing}),
             DrgInpData
-              ( InputData {inpLabel = dmnNamed' "InputData_1axnom3" "Number of Guests"}
+              ( InputData {inpLabel = dmnNamed' "InputData_1axnom3" "Number of Guests", inpVariable = Nothing}
               ),
             DrgInpData
-              ( InputData {inpLabel = dmnNamed' "InputData_0pgvdj9" "Guests with children?"}
+              ( InputData {inpLabel = dmnNamed' "InputData_0pgvdj9" "Guests with children?", inpVariable = Nothing}
               ),
             DrgKS
               ( KnowledgeSource

--- a/languages/haskell/test/dmn13/README.md
+++ b/languages/haskell/test/dmn13/README.md
@@ -1,0 +1,50 @@
+# DMN 1.3 fixtures
+
+Every other `.dmn` / `.xml` file under `test/` is DMN 1.1 or 1.2, which is why
+none of them ever exercised the DMN 1.3 reader. These do.
+
+`baseline.dmn` is the known-good file: one `<decision>` holding one
+`<decisionTable>`, plus the `<inputData>` nodes it refers to. Each of the others
+is `baseline.dmn` plus exactly one feature that used to make the whole document
+fail to unpickle, so a regression points at one thing:
+
+| fixture | what it adds |
+|---|---|
+| `inputdata-variable.dmn` | `<inputData>` with `<description>` and `<variable>` children (B1) |
+| `output-without-label.dmn` | `<input>`/`<output>` with no `label=`, `<output>` with no `typeRef=` (B2) |
+| `default-output-entry.dmn` | `<output>` with a `<defaultOutputEntry>` (B3) |
+| `output-values.dmn` | `<output>` with `<outputValues>`, `<input>` with `<inputValues>` (B3) |
+| `minimal-namespaces.dmn` | declares only the DMN model namespace (B5) |
+| `extra-namespace.dmn` | declares `xsi` and a vendor namespace as well, and carries foreign-namespace attributes (B5) |
+| `feel-number-type.dmn` | `typeRef="number"`, the FEEL numeric type (B4) |
+| `unknown-type.dmn` | `typeRef="tuple<number>"` — must warn and degrade, not crash (B4) |
+| `annotations.dmn` | `<annotation>` columns and per-rule `<annotationEntry>` text |
+
+`not-dmn13.dmn` is a DMN 1.2 file: it must be *rejected*, with a message naming
+the version. Fixtures whose names start with `bad-` must be rejected too; they
+exist to keep the reader from drifting into permissiveness.
+
+Two kinds of refusal are distinguished, because they happen at different stages
+and produce different messages.
+
+*Rejected by the reader* — the document does not unpickle at all, so no table is
+produced and nothing is emitted:
+
+| fixture | why |
+|---|---|
+| `not-dmn13.dmn` | DMN 1.2 namespace |
+| `bad-unknown-element.dmn` | an element the XSD does not allow there |
+| `bad-unknown-attribute.dmn` | an attribute in DMN's own vocabulary that the XSD does not declare |
+| `bad-misordered-child.dmn` | children out of schema order |
+| `unsupported-drgelement.dmn` | a `<businessKnowledgeModel>`: legal DMN 1.3, but not modelled. The message must say *that*, not "this is not DMN 1.3" |
+
+*Refused by the converter* — the document reads fine, but the table cannot be
+represented faithfully, so that table is dropped with an `error` diagnostic and
+`dmnmd` exits nonzero. Emitting a table that can never match, or one whose rules
+have been silently widened, is worse than emitting none:
+
+| fixture | why |
+|---|---|
+| `temporal-type.dmn` | `typeRef="date"`; there is no dmnmd temporal type, and reading it as a string turns every guard into a never-matching string comparison |
+| `bad-rule-arity.dmn` | a rule with more `<inputEntry>` elements than the table has `<input>` columns |
+| `bad-rule-no-output.dmn` | a rule with no `<outputEntry>` at all (the XSD requires at least one) |

--- a/languages/haskell/test/dmn13/annotations.dmn
+++ b/languages/haskell/test/dmn13/annotations.dmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <annotation name="why"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+        <annotationEntry><text>under the age of majority</text></annotationEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+        <annotationEntry><text>working age</text></annotationEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+        <annotationEntry><text>retired</text></annotationEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/bad-misordered-child.dmn
+++ b/languages/haskell/test/dmn13/bad-misordered-child.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <rule id="Rule_1">
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <description>children</description>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/bad-rule-arity.dmn
+++ b/languages/haskell/test/dmn13/bad-rule-arity.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <rule id="Rule_1">
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2a"><text>[18..65]</text></inputEntry>
+        <inputEntry id="UnaryTests_2b"><text>&gt; 0</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/bad-rule-no-output.dmn
+++ b/languages/haskell/test/dmn13/bad-rule-no-output.dmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <rule id="Rule_1">
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/bad-unknown-attribute.dmn
+++ b/languages/haskell/test/dmn13/bad-unknown-attribute.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string" hitPolicy="FIRST"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/bad-unknown-element.dmn
+++ b/languages/haskell/test/dmn13/bad-unknown-element.dmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <sparkline id="Nope_1"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/baseline.dmn
+++ b/languages/haskell/test/dmn13/baseline.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/default-output-entry.dmn
+++ b/languages/haskell/test/dmn13/default-output-entry.dmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string">
+        <defaultOutputEntry id="LiteralExpression_default">
+          <text>"unknown"</text>
+        </defaultOutputEntry>
+      </output>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/extra-namespace.dmn
+++ b/languages/haskell/test/dmn13/extra-namespace.dmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:camunda="http://camunda.org/schema/1.0/dmn"
+             xmlns:acme="https://example.com/acme"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band" acme:owner="risk-team">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age" camunda:inputVariable="age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/feel-number-type.dmn
+++ b/languages/haskell/test/dmn13/feel-number-type.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="premium" label="Premium" typeRef="number"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>100</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>200</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>150</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/inputdata-variable.dmn
+++ b/languages/haskell/test/dmn13/inputdata-variable.dmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age">
+    <description>the applicant's age in whole years</description>
+    <variable id="InformationItem_age" name="age" typeRef="number"/>
+  </inputData>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/minimal-namespaces.dmn
+++ b/languages/haskell/test/dmn13/minimal-namespaces.dmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/not-dmn13.dmn
+++ b/languages/haskell/test/dmn13/not-dmn13.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20180521/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/output-values.dmn
+++ b/languages/haskell/test/dmn13/output-values.dmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_inputValues">
+          <text>[0..150]</text>
+        </inputValues>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string">
+        <outputValues id="UnaryTests_outputValues">
+          <text>"minor","adult","senior"</text>
+        </outputValues>
+      </output>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/output-without-label.dmn
+++ b/languages/haskell/test/dmn13/output-without-label.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/temporal-type.dmn
+++ b/languages/haskell/test/dmn13/temporal-type.dmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="hireDate" name="Hire Date"
+             namespace="https://example.org/dmnmd/test/hireDate">
+  <inputData id="InputData_hired" name="Hired"/>
+  <decision id="Decision_vesting" name="Vesting">
+    <decisionTable id="DecisionTable_vesting" hitPolicy="FIRST">
+      <input id="Input_hired" label="Hired">
+        <inputExpression id="InputExpression_hired" typeRef="date">
+          <text>hired</text>
+        </inputExpression>
+      </input>
+      <output id="Output_vested" name="vested" label="Vested" typeRef="string"/>
+      <rule id="Rule_1">
+        <inputEntry id="UnaryTests_1"><text>&lt; date("2020-01-01")</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"fully"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>-</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"partly"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/unknown-type.dmn
+++ b/languages/haskell/test/dmn13/unknown-type.dmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/"
+             xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/"
+             xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <decision id="Decision_band" name="Band">
+    <informationRequirement id="InformationRequirement_age">
+      <requiredInput href="#InputData_age"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="tuple&lt;number&gt;"/>
+      <rule id="Rule_1">
+        <description>children</description>
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+      <rule id="Rule_2">
+        <inputEntry id="UnaryTests_2"><text>[18..65]</text></inputEntry>
+        <outputEntry id="LiteralExpression_2"><text>"adult"</text></outputEntry>
+      </rule>
+      <rule id="Rule_3">
+        <inputEntry id="UnaryTests_3"><text>&gt; 65</text></inputEntry>
+        <outputEntry id="LiteralExpression_3"><text>"senior"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/languages/haskell/test/dmn13/unsupported-drgelement.dmn
+++ b/languages/haskell/test/dmn13/unsupported-drgelement.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+             id="ageBand" name="Age Band"
+             namespace="https://example.org/dmnmd/test/ageBand">
+  <inputData id="InputData_age" name="Age"/>
+  <businessKnowledgeModel id="BKM_1" name="Band Of">
+    <encapsulatedLogic id="FunctionDefinition_1">
+      <literalExpression id="LiteralExpression_bkm"><text>"minor"</text></literalExpression>
+    </encapsulatedLogic>
+  </businessKnowledgeModel>
+  <decision id="Decision_band" name="Band">
+    <decisionTable id="DecisionTable_band" hitPolicy="FIRST">
+      <input id="Input_age" label="Age">
+        <inputExpression id="InputExpression_age" typeRef="number">
+          <text>age</text>
+        </inputExpression>
+      </input>
+      <output id="Output_band" name="band" label="Band" typeRef="string"/>
+      <rule id="Rule_1">
+        <inputEntry id="UnaryTests_1"><text>&lt; 18</text></inputEntry>
+        <outputEntry id="LiteralExpression_1"><text>"minor"</text></outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>


### PR DESCRIPTION
Fixes the four E0 blockers from `BUILD-SPEC-dmnmd-extensions.md`, plus what adversarial review found while fixing them.

## Why the reader looked broken

It is pinned to DMN 1.3 and **every XML fixture in `test/` is 1.1 or 1.2**, so it rejected all of them. Strict, not broken — but nothing exercised the 1.3 path, and underneath sat four genuine conformance gaps. Each was reproduced against the binary before being touched, and each turned out broader than reported:

| reported | actually |
|---|---|
| `<variable>` unmodelled under `<inputData>` | `<inputData>` modelled **no children at all** — `<description>` failed identically |
| `label` required on `<output>` | it is the **shared** `ColumnLabel` pickler, so `<input>` broke too; and `typeRef` was required while the XSD leaves it optional |
| `<defaultOutputEntry>` unmodelled | `<output>` modelled **no children at all** — `<outputValues>` failed identically |
| `convertType` lacks `number` | confirmed; and the spec's claim that fixing it alone "changes nothing observable" is **false** — on a file free of the other three it is the only failure |

Content models now follow the vendored `xsd/DMN13.xsd` rather than adding special cases. `<inputValues>`/`<outputValues>` populate `ColHeader.enums` (the slot `HP_Priority`/`HP_OutputOrder` already consume); `<annotationEntry>` lands in `row_comments`.

## The rule this change establishes

> Anything we parse but do not yet honour must produce a loud, located diagnostic. Never silently discard.

`XmlToDmnmd` returns `([Diagnostic], [DecisionTable])` instead of calling `error`; `read` is replaced by `readMaybe` behind `mkFEither`, so one bad cell no longer kills a document with a contextless `Prelude.read: no parse`.

**An `Error` means the table is not emitted at all.** Adversarial review of an earlier draft found two cases where this change had replaced a *crash* with a *silently never-matching table* — the worse of the two failure modes:

- a temporal `typeRef` degraded to `String`, so the guard `< date("2020-01-01")` became an equality test against that literal text;
- an unrecognised `typeRef` inferred its type from cells, reaching the same place.

Both now refuse the table and name the type. Rule/column arity mismatches are errors too, rather than being absorbed by `zipWith` — which previously **widened a rule's match set** with no warning at exit 0.

## Exit status

It answers exactly one question: *did something we were asked to read fail to read?*

| input | status |
|---|---|
| valid 1.3 with tables / with no `<decision>` | 0 |
| markdown with tables / prose-only | 0 |
| malformed XML, or DMN 1.1/1.2 | 1 |
| a table refused by the converter | 1 |
| markdown where some tables parsed and others did not | 1, nothing emitted |

`isDecisionTable` draws the prose/table line using `parseHeaderRow`'s own opening tokens — pipe, hit policy, pipe — rather than a proxy. An earlier draft tested only that the first cell *started* with a hit-policy letter, which read `| file | role | provenance |` as an `F` table on the "f" of "file".

## Tests

**177 examples, 0 failures** (was 156). 18 DMN 1.3 fixtures under `test/dmn13/`, one per behaviour *including the refusals*, wired into `DmnXmlSpec`. The 1.1/1.2 fixtures are confirmed still rejected.

One existing expectation was changed deliberately: `an unrecognised typeRef, warning instead of crashing` asserted the behaviour review showed to be unsafe. The replacement documents why.

## Known remaining, not fixed here

- `<annotationEntry>` reaches `row_comments` but `DMN.Translate.JS.annotationsAsComments` discards it again for XML tables, so it does not reach `--to=ts/js/py`.
- `expressionLanguage=` is accepted and ignored on `<definitions>`/`<inputEntry>`/`<outputEntry>`.
- `<import>` and `<itemDefinition>` are accepted and dropped.
- `hitPolicy="COLLECT"` is transpiled as plain first-match by the JS/PY backends (pre-existing: the transpilers ignore hit policy generally, while `evalTable` honours it).
- An unparseable `<inputValues>` — pure domain metadata — escalates to `Error` and refuses the table, which is stricter than it needs to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWUaiYPv2QuBpHqQ6LFNen