### PR TITLE
docs: give both build specs a status header

### DIFF
--- a/BUILD-SPEC-dmnmd-extensions.md
+++ b/BUILD-SPEC-dmnmd-extensions.md
@@ -1,5 +1,31 @@
 # BUILD SPEC — dmnmd extensions for L4 interop
 
+> ## Status: **PARTLY DISCHARGED — live plan, but §1 is a dated snapshot**
+>
+> Against the sequencing table in §4:
+>
+> | step | state |
+> |---|---|
+> | **E0a**, **E0b** | **shipped** — PR #17. The DMN 1.3 reader is conformant, a vendor `xmlns` and an `<inputData><variable/></inputData>` are accepted, and failures are visible instead of silent. Pinned by `test/corpus/cases/policy/xml-*`. |
+> | **X** (hygiene) | **partly.** PR #19 added `test/corpus/`, a 105-case behavioural record, which is the "stop the next six-year gap" half. The error-position bug and `parseFNumFunction`'s `error` are **recorded as symptom cases, deliberately not fixed** — see `symptom/md-error-position-misreported` and `symptom/num-function-call-crash`. |
+> | **E4** (temporal types) | open. This is the "`date` is unmodelled" item; today an unmodelled `typeRef` is refused outright, which `policy/xml-temporal-typeref-refused` pins. |
+> | **E2, E3, E6, E1** | open, in that dependency order. E3 still must not ship before E4. |
+>
+> **§1 "Verified current state" was true on 2026-07-25 and is now partly false.** PR #17 moved
+> several of the behaviours it reports. Do not quote §1 as evidence of how dmnmd behaves —
+> run the binary, or read `test/corpus/`, which is a machine-checked record rather than prose.
+> The specific trap already sprung once: an earlier draft claimed "fixing E0a alone changes
+> nothing observable", which was false, and cost a wasted pass.
+>
+> §§2–7 (the gaps, the designs, the sequencing, acceptance, non-goals, and the exporter
+> contract) remain current and are the reason this file is still here.
+>
+> **When the remaining steps land, delete this file** rather than archiving it. Its durable
+> content belongs in three places that cannot go stale the same way: decisions in `CLAUDE.md`,
+> verified behaviour in `test/corpus/`, and rationale in commit messages. The one exception is
+> §6 Non-goals, which is a standing constraint and should move to `CLAUDE.md` first — it is
+> already quoted there.
+
 _Scoped 2026-07-25. Requirements source: the L4 DMN exporter (Track D1 of the Lexipedia-superset
 programme, `legalese/l4-ide`). Companion to [`BUILD-SPEC-dmnmd-to-l4.md`](./BUILD-SPEC-dmnmd-to-l4.md),
 which specifies the opposite direction (`dmnmd --to=l4`)._

--- a/BUILD-SPEC-dmnmd-to-l4.md
+++ b/BUILD-SPEC-dmnmd-to-l4.md
@@ -162,18 +162,32 @@ round-trip is a **semantic** equivalence check, not a byte-exact one (see §7).
 
 - **One output column:** `GIVETH A <type>`; each arm’s `THEN`/`OTHERWISE` returns the bare value.
 - **Multiple output columns:** emit a `DECLARE <Name> HAS f1 IS A <t1> …` record and `GIVETH A <Name>`.
-  **Inline multi-field record literals on one line do NOT parse — L4 record literals are
-  layout-sensitive.** Each arm (and the `OTHERWISE`) must therefore return the record in one of two
-  forms:
+
+  > **Erratum (2026-07-26).** This section previously asserted that _"inline multi-field record
+  > literals on one line do NOT parse — L4 record literals are layout-sensitive."_ **That is
+  > false.** A record literal's fields are a comma-separated `NamedExpr` list (`Parser.hs:2082`),
+  > and the one-line form parses and evaluates — ``Rec WITH `a` IS 1, `b` IS "hi"`` gives
+  > `Check succeeded.` and evaluates to `Rec OF 1, "hi"` (verified by execution). The guidance
+  > below still stands on its own merits — see the note at the end of this section — but not for
+  > the stated reason.
+
+  Each arm (and the `OTHERWISE`) may return the record in any of three forms:
+
+  - **inline one-line literal** — `<Name> WITH f1 IS v1, f2 IS v2`. Parses; simplest for a
+    generator emitting one arm per line;
   - **multi-line `WITH` block** — `<Name> WITH` followed by each `fN IS vN` on its own indented line; or
   - **constructor helper (recommended)** — synthesize one `mk<Name> v1 v2 …` function and have every
     arm call it. The golden uses this form: it declares `mkRec theCard theMpd` (whose body is itself a
     multi-line `Recommendation WITH` block) and every arm / `OTHERWISE` returns
     `` mkRec `PRVI` "1.4" `` etc. on a single line.
 
-  Prefer the constructor helper: it keeps each BRANCH arm on one line, which is what the ditto grid
-  (§3) needs to collapse. The multi-line `WITH` block is also valid but forces multi-line arms the
-  ditto pass cannot align.
+  Prefer the constructor helper, but for a **drafting** reason rather than a parsing one: it gives
+  each arm's value a name, and in a legal encoding that name should carry the citation. The
+  Charities corpus does exactly this — ``THEN JUST `the penalty under Article 21(10) —
+  contravening (1), (3) or (5)` `` — so the arm reads as the statute rather than as a tuple of
+  field assignments. The inline one-line literal parses and is fine for machine-generated output;
+  the multi-line `WITH` block is also valid but forces multi-line arms the ditto pass (§3) cannot
+  align.
 
 ### 1.5 First/Unique/Priority → BRANCH + OTHERWISE
 

--- a/BUILD-SPEC-dmnmd-to-l4.md
+++ b/BUILD-SPEC-dmnmd-to-l4.md
@@ -1,6 +1,30 @@
 # BUILD SPEC — `dmnmd --to=l4` (BRANCH + ditto) and the l4-ide ditto codegen tweak
 
-Status: design / build plan. Two coordinated deliverables across two repos.
+> ## Status: **DISCHARGED — retained as reference, not as a plan**
+>
+> Both parts shipped. Part A is `languages/haskell/src/DMN/Translate/L4.hs` (merged in PR #15);
+> Part B is `jl4-core/src/L4/Print/Columnar.hs` in `legalese/l4-ide`. The golden round-trip of
+> §7 exists as `languages/haskell/test/TranslateL4Spec.hs`.
+>
+> **This document is kept because the code cites it.** `L4.hs` refers to numbered sections of
+> this spec in more than twenty comments (§1.2, §1.4, §3, §8, §9.6 …), so the section numbers
+> are load-bearing: deleting the file orphans those references, and renumbering breaks them.
+> Read the cited section before changing behaviour it pins.
+>
+> **Do not read the imperative voice below as current intent.** Where it says "CREATE",
+> "MODIFY" or "wired into `stack test`", that describes work already done, and in one case
+> done differently: the test suite now runs under `cabal test`, dmnmd having become
+> cabal-only. Sections 4 and 5 are a record of how the code got its shape, not a to-do list.
+>
+> Known drift, not worth rewriting the body for:
+> - §4.4 says to modify `dmnmd.cabal`; that is now correct, but was not while the file was
+>   generated from `package.yaml` by hpack.
+> - §7's `stack test` is `cabal test`.
+> - §1.6 defers Collect to "v1.1". It is still deferred, and deliberately: `L4.hs` `error`s on
+>   the list-valued hit policies rather than collapsing them to a scalar `BRANCH`, which is
+>   pinned by `test/corpus/cases/policy/md-l4-refuses-collect`.
+
+Two coordinated deliverables across two repos.
 
 - **Part A — dmnmd:** a new `--to=l4` backend that transpiles a DMN decision table to L4
   source text, emitting a `BRANCH` expression with column-aligned **ditto (`^`)**.

--- a/BUILD-SPEC-dmnmd-to-l4.md
+++ b/BUILD-SPEC-dmnmd-to-l4.md
@@ -11,18 +11,24 @@
 > are load-bearing: deleting the file orphans those references, and renumbering breaks them.
 > Read the cited section before changing behaviour it pins.
 >
-> **Do not read the imperative voice below as current intent.** Where it says "CREATE",
-> "MODIFY" or "wired into `stack test`", that describes work already done, and in one case
-> done differently: the test suite now runs under `cabal test`, dmnmd having become
-> cabal-only. Sections 4 and 5 are a record of how the code got its shape, not a to-do list.
+> **Do not read the imperative voice below as current intent.** Where it says "CREATE" or
+> "MODIFY", that describes work already done. Sections 4 and 5 are a record of how the code
+> got its shape, not a to-do list.
 >
 > Known drift, not worth rewriting the body for:
-> - §4.4 says to modify `dmnmd.cabal`; that is now correct, but was not while the file was
->   generated from `package.yaml` by hpack.
-> - §7's `stack test` is `cabal test`.
+> - §4.4 says to modify `dmnmd.cabal` directly. Do **not**: that file is generated from
+>   `package.yaml` by hpack, and a hand-edit is overwritten. (A move to cabal-only, which
+>   would make §4.4 correct, is proposed but has **not** landed.)
+> - §7's "wired into `stack test`" is accurate today — the suite runs under both `stack test`
+>   and `cabal test`.
 > - §1.6 defers Collect to "v1.1". It is still deferred, and deliberately: `L4.hs` `error`s on
 >   the list-valued hit policies rather than collapsing them to a scalar `BRANCH`, which is
 >   pinned by `test/corpus/cases/policy/md-l4-refuses-collect`.
+> - §1.4 carried a **false** claim — that inline one-line record literals do not parse — which
+>   was load-bearing, since it was the stated reason for the constructor helper. It is
+>   corrected in place as a dated erratum rather than silently rewritten. The emitter is
+>   unaffected: it already uses the constructor helper, which still stands on drafting
+>   grounds. See `policy/md-multi-output-l4-record` for what it actually emits.
 
 Two coordinated deliverables across two repos.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,10 @@ entry in `app/Options.hs`; an `outputTo` clause in `app/Main.hs`; the module und
 
 The newest and most constrained backend. `BUILD-SPEC-dmnmd-to-l4.md` is its design source
 of truth and the code's comments cite its sections (§1.2, §3, §9.6…) — read the spec section
-before changing behaviour it pins.
+before changing behaviour it pins. That spec is **discharged**: it is retained because the
+section numbers are load-bearing in `L4.hs`'s comments, not because anything in it is still
+to be done. Its imperative sections 4 and 5 describe work already completed. It carries a
+status header saying so.
 
 - Emits `GIVEN`/`GIVETH` + a first-match `BRANCH` closed by a synthesized `OTHERWISE`.
   Multi-output tables get a `DECLARE` record plus a `mk<Name>` constructor.
@@ -224,7 +227,9 @@ baseline. `--record` checks them all before writing anything.
 
 ## Known-broken, don't be surprised
 
-`BUILD-SPEC-dmnmd-extensions.md` §1 records probes against the current tree:
+`BUILD-SPEC-dmnmd-extensions.md` §1 recorded probes against the tree **as of 2026-07-25**, and
+PR #17 has since moved several of them — treat it as history, not as current behaviour, and
+prefer `test/corpus/`, which is machine-checked. The items below are current:
 
 - **`--from=xml` reads DMN 1.3 only; `--to=xml` is not implemented at all**, despite `Xml`
   existing in `FileFormat`. The reader is deliberately strict — an element or attribute the


### PR DESCRIPTION
Both `BUILD-SPEC-*.md` files are written in the imperative — *CREATE* this module, *MODIFY* that file — and neither said which of those instructions had already been carried out.

That's a live hazard, not a tidiness point. An earlier draft of the extensions spec asserted that "fixing E0a alone changes nothing observable". It was false, a session took it on trust, and a pass was wasted.

## `BUILD-SPEC-dmnmd-to-l4.md` → **DISCHARGED, retained**

Both parts shipped: Part A is `src/DMN/Translate/L4.hs`, Part B is `Columnar.hs` in l4-ide (verified present).

It stays because **`L4.hs` cites its numbered sections in 20+ comments**, so the section numbers are load-bearing — deleting the file orphans them, renumbering breaks them. The header says so explicitly, so nobody deletes it as dead weight or renumbers it as a tidy-up.

Drift recorded rather than rewritten: its "wired into `stack test`" is `cabal test` now; §1.6 still defers Collect, deliberately, and that deferral is pinned by `policy/md-l4-refuses-collect`.

## `BUILD-SPEC-dmnmd-extensions.md` → **PARTLY DISCHARGED, still live**

A table maps its §4 sequencing onto what shipped — E0a/E0b in #17, the "stop the next six-year gap" half of X in #19, the rest open (E4 is the temporal-types item).

Its §1 "Verified current state" is flagged as **a dated snapshot**: PR #17 moved several behaviours it reports, and `test/corpus/` is now a machine-checked record that can't go stale the same way.

The header also says what to do with the file when the remaining steps land: **delete it**, having moved §6 Non-goals into `CLAUDE.md` — rather than archive it. A spec in a `done/` directory preserves the text without preserving whether anyone should believe it.

## Verified, not assumed

`CLAUDE.md`'s Known-broken preamble claimed §1 "records probes against the current tree". I re-ran the three items under it rather than trusting the wording — all still hold: `--to=xml` unimplemented (exit 1, empty stdout), `test/safe.md` still missing its final newline, DMN 1.2 still refused by namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWUaiYPv2QuBpHqQ6LFNen