### PR TITLE
chore(deps): drop three dependencies the library never needed

### DIFF
--- a/languages/haskell/Makefile
+++ b/languages/haskell/Makefile
@@ -52,8 +52,28 @@ tests-watch:
 	  --test ':main --rerun --failure-report=TESTREPORT --rerun-all-on-success'
 
 # Gives very quick iteration, especially when used with -- $> command
+#
+# --build-depends pretty-simple is load-bearing, and this is where it lives
+# rather than in dmnmd.cabal. src/DMN/XML/ParseDMN.hs:1124 holds
+# `-- $> :m + Text.Pretty.Simple` and --allow-eval runs it for real; the repl
+# ghcid starts hides every package the library stanza does not name — and no
+# module imports pretty-simple, so the stanza must not name it. This flag also
+# BUILDS the package when the store lacks it, which a `:set -package` in a
+# .ghci would not.
+#
+# Only this target. ghcid-tests is a multi-component repl and GHC refuses
+# `:module` in one outright ("Command is not supported (yet) in multi-mode"),
+# so that eval cannot run there whatever the packages are.
+#
+# If the eval instead reports `Ambiguous module name 'Text.Pretty.Simple' ...
+# found in multiple packages: pretty-simple-4.1.4.0 pretty-simple-4.1.4.0`,
+# that is NOT this flag and predates it — the same failure reproduces on the
+# commit before this one with the old command. It is a `:set -package
+# pretty-simple` line in your ~/.ghci naming the package a second time while
+# ~/.cabal/store holds two builds of that same version. Delete that ~/.ghci
+# line; this flag supersedes it.
 ghcid:
-	ghcid --command "cabal repl lib:dmnmd" --allow-eval
+	ghcid --command "cabal repl lib:dmnmd --build-depends pretty-simple" --allow-eval
 
 # Refresh the DMN->L4 golden fixtures (test/golden/) from the canonical homelab
 # sources. Committed copies are used because the homelab repo is not guaranteed

--- a/languages/haskell/dmnmd.cabal
+++ b/languages/haskell/dmnmd.cabal
@@ -62,19 +62,25 @@ library
   hs-source-dirs:  src
   build-depends:
       containers
-    -- Data.List.Utils
-    , MissingH
     , hxt
     -- a more convenient Iso for the XML pickling
     , lens
-    , optparse-applicative
     -- Control.Monad.Combinators.Expr
     , parser-combinators
-    -- NOT dead. DMN/XML/ParseDMN.hs ends in a `-- $>` block that does
-    -- `:m + Text.Pretty.Simple`, which `make ghcid` evaluates for real
-    -- (ghcid --allow-eval). Drop this and that dev loop breaks, with nothing
-    -- in CI to notice.
-    , pretty-simple
+    -- pretty-simple is deliberately absent, and the note that used to sit here
+    -- was half right. No module imports it; its only uses in the tree are the
+    -- two `-- $>` lines at src/DMN/XML/ParseDMN.hs:1124-1126, which
+    -- `make ghcid` really does evaluate (ghcid --allow-eval). And that loop
+    -- really does need the package: `cabal repl lib:dmnmd` hides every package
+    -- this stanza does not name — ask that repl for
+    -- `:m + System.Console.Haskeline` and it answers "hidden package" even
+    -- though the executable in this same project depends on it — so with the
+    -- dependency nowhere, the eval fails the same way.
+    -- What the note got wrong is whose need it is. It is the ghcid command's,
+    -- not the library's, so the Makefile's `ghcid` target passes
+    -- `--build-depends pretty-simple` and every consumer of this library stops
+    -- paying for a dev loop. If that eval starts reporting a hidden package,
+    -- look there, not here.
     -- number parsing
     , scientific
     , split

--- a/languages/haskell/src/DMN/SFeelGrammar.hs
+++ b/languages/haskell/src/DMN/SFeelGrammar.hs
@@ -6,7 +6,6 @@ import Text.Megaparsec
 import Text.Megaparsec.Char
 import Control.Monad.Combinators.Expr
 import qualified Text.Megaparsec.Char.Lexer as L
-import Options.Applicative (Alternative((<|>)))
 import DMN.Types
 import DMN.ParsingUtils
 import Data.Text (Text)

--- a/languages/haskell/src/DMN/Types.hs
+++ b/languages/haskell/src/DMN/Types.hs
@@ -8,7 +8,6 @@ module DMN.Types where
 
 import Prelude hiding (takeWhile)
 import qualified Data.Map as Map
-import Data.List.Utils (replace)
 import Data.Maybe (isJust)
 
 -- | We implement DMN Hit Policies.
@@ -122,8 +121,18 @@ var_name :: ColHeader -> String
 var_name = underscore . varname
 
 -- | utility function replaces spaces with underscores.
+--
+-- Was @Data.List.Utils.replace " " "_"@, and was the package's only use of
+-- MissingH — which brought nine packages, three of them C-compiling, into the
+-- library's closure for this one line. For a single-character needle @replace@
+-- /is/ a pointwise map: it is @intercalate new . split old@, and splitting on
+-- one character and rejoining reproduces every other character unchanged.
+-- Checked exhaustively against MissingH-1.6.0.3's own source rather than
+-- argued: all 3280 strings of length <= 7 over @{' ', '_', 'a'}@ agree, and
+-- that alphabet is complete because no other character is distinguishable to
+-- this function.
 underscore :: String -> String
-underscore = replace " " "_"
+underscore = map (\c -> if c == ' ' then '_' else c)
 
 -- | a decision table has a name, a hit policy, a set of column headers, and data rows beneath.
 data DecisionTable = DTable { tableName :: String


### PR DESCRIPTION
`MissingH`, `optparse-applicative` and `pretty-simple` sat in the **library** stanza. No library module uses any of them.

**Library transitive closure: 84 packages → 67.** Seventeen leave, nothing enters, no version selection changes. That is what a downstream `build-depends: dmnmd` stops paying for — which is the remaining objection now that dmnmd links no C library.

| removed | what leaves |
|---|---|
| `MissingH` (one call to `replace`) | `MissingH`, `hslogger`, `network`, `network-bsd`, `old-locale`, `old-time`, `regex-base`, `regex-compat`, `regex-posix` |
| `optparse-applicative` (a re-export of `Alternative`, which is in `base`) + `pretty-simple` | `optparse-applicative`, `pretty-simple`, `prettyprinter`, `prettyprinter-ansi-terminal`, `ansi-terminal`, `ansi-terminal-types`, `colour` |
| all three jointly | `process` — it needed all three, since two of them are independent consumers |

The last two are synergistic: neither alone unloads the prettyprinter/ansi-terminal stack, because each is the other's co-consumer.

### The part that matters beyond package count

`MissingH` was putting **C compilation and `./configure` back into the library closure** of a package that had just finished retiring `regex-pcre`. `regex-posix` ships `cbits/myfree.c` and FFI-binds libc's POSIX.2 regex; `network` and `old-time` are `build-type: Configure`.

Stated carefully so it doesn't get sharpened later: these bind libc and OS facilities rather than a third-party library, so **`shell.nix` is still correct to be empty and `pkg-config`/`libpcre3-dev` do not come back**. What comes back is C compilation in the closure, which is the thing that obstructs a wasm32 cross-build — the constraint `shell.nix`'s comment and l4-ide's `WASM-LSP-SPEC.md` both exist to protect.

### Verification

- **2,772 invocation pairs — 231 files × 6 formats × ±`-r` — with 0 differences** in stdout, stderr or exit status. Both worktrees' build dirs deleted and rebuilt from source, both binaries run from a single cwd so paths cannot differ artificially. Not vacuous: 220 distinct underscored identifiers appear in the compared output, e.g. `def Example_2 ( Season, Guest_Count )`.
- **The `replace` replacement was proven, not argued.** A checker linked the real `MissingH-1.6.0.3` and compared it against the new `underscore` over **342,225 inputs** — every hostile shape (empty, no spaces, consecutive, leading, trailing, all-space runs, non-ASCII) plus a full BMP codepoint sweep. Zero mismatches.
- `cabal test` **203 examples, 0 failures** on both sides, with the `l4` golden shelling out for real. `make corpus` **181 unchanged, 0 policy regressions** on both sides, each using its own worktree's binary.
- Warning and error lines identical line-for-line; both `-Werror` flags intact.
- **The ghcid loop still works, verified non-interactively.** `pretty-simple` moved to the `Makefile` via `cabal repl --build-depends`; driving that repl and feeding it the `-- $>` block's own commands resolves `Text.Pretty.Simple` and pretty-prints. The control — same repl, flag removed — fails with `hidden package 'pretty-simple-4.1.4.0'`, so the flag is doing the work.

The `pretty-simple` comment in `dmnmd.cabal` claimed the library needed it. It didn't; the dev loop did. Amended rather than deleted, so whoever breaks that loop can find out why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjtavSnGwAnCHpNNaVopcb